### PR TITLE
Update poison dependency to ~> 1.3.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule OAuth2.Mixfile do
     [
       {:hackney, "~> 0.14.1"},
       {:httpoison, "~> 0.5.0"},
-      {:poison, "~> 1.2"},
+      {:poison, "~> 1.3"},
       {:cowboy, "~> 1.0", only: :test},
       {:plug, "~> 0.9.0"},
     ]


### PR DESCRIPTION
This updates the dependency on poison to work with the beta of Phoenix 0.8.0