### PR TITLE
Link to the official oauth2 rfc in AuthCode

### DIFF
--- a/lib/oauth2/strategy/auth_code.ex
+++ b/lib/oauth2/strategy/auth_code.ex
@@ -2,7 +2,7 @@ defmodule OAuth2.Strategy.AuthCode do
   @moduledoc """
   The Authorization Code Strategy.
 
-  http://tools.ietf.org/html/draft-ietf-oauth-v2-15#section-4.1
+  http://tools.ietf.org/html/rfc6749#section-1.3.1
   """
 
   use OAuth2.Strategy


### PR DESCRIPTION
This modifies the reference link for the Authorization Code Strategy to point
to the official RFC rather than the section in the original draft.