### PR TITLE
Replace erlang.now with os.timestamp

### DIFF
--- a/lib/oauth2/util.ex
+++ b/lib/oauth2/util.ex
@@ -2,7 +2,7 @@ defmodule OAuth2.Util do
   @moduledoc false
 
   def unix_now do
-    {mega, sec, _micro} = :erlang.now
+    {mega, sec, _micro} = :os.timestamp
     (mega * 1_000_000) + sec
   end
 


### PR DESCRIPTION
:erlang.now has been deprecated in erlang 18, so have changed the single
use to use :os.timestamp instead.