### PR TITLE
POST/PUT methods via generic request with the access token, and possibility for default headers 

### DIFF
--- a/lib/oauth2/access_token.ex
+++ b/lib/oauth2/access_token.ex
@@ -55,7 +55,7 @@ defmodule OAuth2.AccessToken do
   @doc """
   Makes a `GET` request to the given URL using the AccessToken.
   """
-  def get(token, url, headers \\ [], opts \\ []), do: request(:get, token, url, "", headers, opts)
+  def get(token, url, headers \\ [], opts \\ []), do: request(:get, token, url, headers, opts)
 
   @doc """
   Makes a `GET` request to the given URL using the AccessToken.
@@ -63,7 +63,7 @@ defmodule OAuth2.AccessToken do
   An `OAuth2.Error` exception is raised if the request results in an
   error tuple (`{:error, reason}`).
   """
-  def get!(token, url, headers \\ [], opts \\ []), do: request!(:get, token, url, "", headers, opts)
+  def get!(token, url, headers \\ [], opts \\ []), do: request!(:get, token, url, headers, opts)
 
   @doc """
   Makes a `PUT` request to the given URL using the AccessToken.
@@ -95,7 +95,7 @@ defmodule OAuth2.AccessToken do
   Makes a request of given type to the given URL using the AccessToken.
   """
   def request(method, token, url, body \\ "", headers \\ [], opts \\ []) do
-    case Request.request(method, process_url(token, url), req_headers(token, headers), opts) do
+    case Request.request(method, process_url(token, url), body, req_headers(token, headers), opts) do
       {:ok, response} -> {:ok, response.body}
       {:error, reason} -> {:error, %Error{reason: reason}}
     end
@@ -108,7 +108,7 @@ defmodule OAuth2.AccessToken do
   error tuple (`{:error, reason}`).
   """
   def request!(method, token, url, body \\ "", headers \\ [], opts \\ []) do
-    case Request.request(method, process_url(token, url), req_headers(token, headers), opts) do
+    case Request.request(method, process_url(token, url), body, req_headers(token, headers), opts) do
       {:ok, response} -> response
       {:error, error} -> raise error
     end

--- a/lib/oauth2/access_token.ex
+++ b/lib/oauth2/access_token.ex
@@ -55,7 +55,7 @@ defmodule OAuth2.AccessToken do
   @doc """
   Makes a `GET` request to the given URL using the AccessToken.
   """
-  def get(token, url, headers \\ [], opts \\ []), do: request(:get, url, headers, opts)
+  def get(token, url, headers \\ [], opts \\ []), do: request(:get, token, url, headers, opts)
 
   @doc """
   Makes a `GET` request to the given URL using the AccessToken.
@@ -63,12 +63,12 @@ defmodule OAuth2.AccessToken do
   An `OAuth2.Error` exception is raised if the request results in an
   error tuple (`{:error, reason}`).
   """
-  def get!(token, url, headers \\ [], opts \\ []), do: request!(:get, url, headers, opts)
+  def get!(token, url, headers \\ [], opts \\ []), do: request!(:get, token, url, headers, opts)
 
   @doc """
   Makes a `PUT` request to the given URL using the AccessToken.
   """
-  def put(token, url, headers \\ [], opts \\ []), do: request(:put, url, headers, opts)
+  def put(token, url, headers \\ [], opts \\ []), do: request(:put, token, url, headers, opts)
 
   @doc """
   Makes a `PUT` request to the given URL using the AccessToken.
@@ -76,12 +76,12 @@ defmodule OAuth2.AccessToken do
   An `OAuth2.Error` exception is raised if the request results in an
   error tuple (`{:error, reason}`).
   """
-  def put!(token, url, headers \\ [], opts \\ []), do: request!(:put, url, headers, opts)
+  def put!(token, url, headers \\ [], opts \\ []), do: request!(:put, token, url, headers, opts)
 
   @doc """
   Makes a `POST` request to the given URL using the AccessToken.
   """
-  def post(token, url, headers \\ [], opts \\ []), do: request(:post, url, headers, opts)
+  def post(token, url, headers \\ [], opts \\ []), do: request(:post, token, url, headers, opts)
 
   @doc """
   Makes a `POST` request to the given URL using the AccessToken.
@@ -89,7 +89,7 @@ defmodule OAuth2.AccessToken do
   An `OAuth2.Error` exception is raised if the request results in an
   error tuple (`{:error, reason}`).
   """
-  def post!(token, url, headers \\ [], opts \\ []), do: request!(:post, url, headers, opts)
+  def post!(token, url, headers \\ [], opts \\ []), do: request!(:post, token, url, headers, opts)
 
   @doc """
   Makes a request of given type to the given URL using the AccessToken.

--- a/lib/oauth2/access_token.ex
+++ b/lib/oauth2/access_token.ex
@@ -55,7 +55,7 @@ defmodule OAuth2.AccessToken do
   @doc """
   Makes a `GET` request to the given URL using the AccessToken.
   """
-  def get(token, url, headers \\ [], opts \\ []), do: request(:get, token, url, body, headers, opts)
+  def get(token, url, headers \\ [], opts \\ []), do: request(:get, token, url, "", headers, opts)
 
   @doc """
   Makes a `GET` request to the given URL using the AccessToken.
@@ -63,7 +63,7 @@ defmodule OAuth2.AccessToken do
   An `OAuth2.Error` exception is raised if the request results in an
   error tuple (`{:error, reason}`).
   """
-  def get!(token, url, headers \\ [], opts \\ []), do: request!(:get, token, url, body, headers, opts)
+  def get!(token, url, headers \\ [], opts \\ []), do: request!(:get, token, url, "", headers, opts)
 
   @doc """
   Makes a `PUT` request to the given URL using the AccessToken.

--- a/lib/oauth2/access_token.ex
+++ b/lib/oauth2/access_token.ex
@@ -55,7 +55,7 @@ defmodule OAuth2.AccessToken do
   @doc """
   Makes a `GET` request to the given URL using the AccessToken.
   """
-  def get(token, url, headers \\ [], opts \\ []), do: request(:get, token, url, headers, opts)
+  def get(token, url, headers \\ [], opts \\ []), do: request(:get, token, url, body, headers, opts)
 
   @doc """
   Makes a `GET` request to the given URL using the AccessToken.
@@ -63,7 +63,7 @@ defmodule OAuth2.AccessToken do
   An `OAuth2.Error` exception is raised if the request results in an
   error tuple (`{:error, reason}`).
   """
-  def get!(token, url, headers \\ [], opts \\ []), do: request!(:get, token, url, headers, opts)
+  def get!(token, url, headers \\ [], opts \\ []), do: request!(:get, token, url, body, headers, opts)
 
   @doc """
   Makes a `PUT` request to the given URL using the AccessToken.

--- a/lib/oauth2/access_token.ex
+++ b/lib/oauth2/access_token.ex
@@ -152,6 +152,6 @@ defmodule OAuth2.AccessToken do
   defp normalize_token_type(string), do: string
 
   defp req_headers(token, headers) do
-    [{"Authorization", "#{token.token_type} #{token.access_token}"} | headers]
+    [{"Authorization", "#{token.token_type} #{token.access_token}"} | headers] ++ token.client.headers
   end
 end

--- a/lib/oauth2/access_token.ex
+++ b/lib/oauth2/access_token.ex
@@ -55,12 +55,7 @@ defmodule OAuth2.AccessToken do
   @doc """
   Makes a `GET` request to the given URL using the AccessToken.
   """
-  def get(token, url, headers \\ [], opts \\ []) do
-    case Request.get(process_url(token, url), req_headers(token, headers), opts) do
-      {:ok, response} -> {:ok, response.body}
-      {:error, reason} -> {:error, %Error{reason: reason}}
-    end
-  end
+  def get(token, url, headers \\ [], opts \\ []), do: request(:get, url, headers, opts)
 
   @doc """
   Makes a `GET` request to the given URL using the AccessToken.
@@ -68,8 +63,52 @@ defmodule OAuth2.AccessToken do
   An `OAuth2.Error` exception is raised if the request results in an
   error tuple (`{:error, reason}`).
   """
-  def get!(token, url, headers \\ [], opts \\ []) do
-    case get(token, url, req_headers(token, headers), opts) do
+  def get!(token, url, headers \\ [], opts \\ []), do: request!(:get, url, headers, opts)
+
+  @doc """
+  Makes a `PUT` request to the given URL using the AccessToken.
+  """
+  def put(token, url, headers \\ [], opts \\ []), do: request(:put, url, headers, opts)
+
+  @doc """
+  Makes a `PUT` request to the given URL using the AccessToken.
+
+  An `OAuth2.Error` exception is raised if the request results in an
+  error tuple (`{:error, reason}`).
+  """
+  def put!(token, url, headers \\ [], opts \\ []), do: request!(:put, url, headers, opts)
+
+  @doc """
+  Makes a `POST` request to the given URL using the AccessToken.
+  """
+  def post(token, url, headers \\ [], opts \\ []), do: request(:post, url, headers, opts)
+
+  @doc """
+  Makes a `POST` request to the given URL using the AccessToken.
+
+  An `OAuth2.Error` exception is raised if the request results in an
+  error tuple (`{:error, reason}`).
+  """
+  def post!(token, url, headers \\ [], opts \\ []), do: request!(:post, url, headers, opts)
+
+  @doc """
+  Makes a request of given type to the given URL using the AccessToken.
+  """
+  def request(method, token, url, body \\ "", headers \\ [], opts \\ []) do
+    case Request.request(method, process_url(token, url), req_headers(token, headers), opts) do
+      {:ok, response} -> {:ok, response.body}
+      {:error, reason} -> {:error, %Error{reason: reason}}
+    end
+  end
+
+  @doc """
+  Makes a request of given type to the given URL using the AccessToken.
+
+  An `OAuth2.Error` exception is raised if the request results in an
+  error tuple (`{:error, reason}`).
+  """
+  def request!(method, token, url, body \\ "", headers \\ [], opts \\ []) do
+    case Request.request(method, process_url(token, url), req_headers(token, headers), opts) do
       {:ok, response} -> response
       {:error, error} -> raise error
     end

--- a/lib/oauth2/access_token.ex
+++ b/lib/oauth2/access_token.ex
@@ -68,7 +68,7 @@ defmodule OAuth2.AccessToken do
   @doc """
   Makes a `PUT` request to the given URL using the AccessToken.
   """
-  def put(token, url, headers \\ [], opts \\ []), do: request(:put, token, url, headers, opts)
+  def put(token, url, body \\ "", headers \\ [], opts \\ []), do: request(:put, token, url, body, headers, opts)
 
   @doc """
   Makes a `PUT` request to the given URL using the AccessToken.
@@ -76,12 +76,12 @@ defmodule OAuth2.AccessToken do
   An `OAuth2.Error` exception is raised if the request results in an
   error tuple (`{:error, reason}`).
   """
-  def put!(token, url, headers \\ [], opts \\ []), do: request!(:put, token, url, headers, opts)
+  def put!(token, url, body \\ "", headers \\ [], opts \\ []), do: request!(:put, token, url, body, headers, opts)
 
   @doc """
   Makes a `POST` request to the given URL using the AccessToken.
   """
-  def post(token, url, headers \\ [], opts \\ []), do: request(:post, token, url, headers, opts)
+  def post(token, url, body \\ "", headers \\ [], opts \\ []), do: request(:post, token, url, body, headers, opts)
 
   @doc """
   Makes a `POST` request to the given URL using the AccessToken.
@@ -89,7 +89,7 @@ defmodule OAuth2.AccessToken do
   An `OAuth2.Error` exception is raised if the request results in an
   error tuple (`{:error, reason}`).
   """
-  def post!(token, url, headers \\ [], opts \\ []), do: request!(:post, token, url, headers, opts)
+  def post!(token, url, body \\ "", headers \\ [], opts \\ []), do: request!(:post, token, url, body, headers, opts)
 
   @doc """
   Makes a request of given type to the given URL using the AccessToken.


### PR DESCRIPTION
@scrogson Thanks for this library!

I find it awkward that I have to use another library to make api calls, since via oauth2 I can only make GET requests? I have exposed PUT/POST and left generic request so one can make also others if needed. I did not add DELETE/HEAD before discussing the idea with you.

    AccessToken.post/post!...    
    AccessToken.put/put!...

The other thing, I was missing option to set default headers in requests, so now if you put the header on the client, it is asumed in all: 

    def client...
      OAuth2.new([
      ....
      ]) |> put_header("Content-Type", "application/json")
    end


As a side note: the docs of oauth2 are not so clear regarding one thing. I was scratching my head what to do with the access_token that is persisted - how to make a AccessToken struct out of it again to use in the later requests. Would have been helpful to show this example in the strategy:


    def client do
       OAuth2.new([
        .....
       ])
    end

    def access_token(token) do
       OAuth2.AccessToken.new(token, client)
    end



Thanks again!

Cheers
