### PR TITLE
empty body should not be decoded

### DIFF
--- a/lib/oauth2/response.ex
+++ b/lib/oauth2/response.ex
@@ -33,6 +33,7 @@ defmodule OAuth2.Response do
     }
   end
 
+  defp decode_response_body("", _type), do: ""
   defp decode_response_body(body, "application/json"), do:
     Poison.decode!(body)
   defp decode_response_body(body, type) when type in @query, do:


### PR DESCRIPTION
If the response body is empty, it should not even be attempted to be decoded. This is a case for example in delete requests where no content body would be returned. The same allows keeping default headers content type for all other requests.