### PR TITLE
Don't double send params... causes issues with LinkedIn in particular

### DIFF
--- a/lib/oauth2/client.ex
+++ b/lib/oauth2/client.ex
@@ -161,7 +161,7 @@ defmodule OAuth2.Client do
   end
 
   defp to_url(client, :token_url) do
-    {client, client.token_url}
+    {client, endpoint(client, client.token_url)}
   end
 
   defp to_url(client, endpoint) do

--- a/lib/oauth2/client.ex
+++ b/lib/oauth2/client.ex
@@ -160,6 +160,10 @@ defmodule OAuth2.Client do
     end
   end
 
+  defp to_url(client, :token_url) do
+    {client, client.token_url}
+  end
+
   defp to_url(client, endpoint) do
     endpoint = Map.get(client, endpoint)
     url = endpoint(client, endpoint) <> "?" <> URI.encode_query(client.params)

--- a/mix.exs
+++ b/mix.exs
@@ -23,9 +23,9 @@ defmodule OAuth2.Mixfile do
      {:httpoison, "~> 0.6"},
      {:poison, "~> 1.3"},
      {:plug, "~> 1.0"},
+     {:cowboy, "~> 1.0", optional: true},
 
      # Test dependencies
-     {:cowboy, "~> 1.0", only: :test},
      {:excoveralls, "~> 0.3", only: :test},
 
      # Docs dependencies


### PR DESCRIPTION
Ideally, one would pass through the request method to determine if you need to put the params on the url or in the body, or the behavior could be extended to allow the strategy to distinguish between params vs body. In either case, the spec says the params go in the body only (https://tools.ietf.org/html/rfc6749#section-4.1.3)

I also had to switch around some deps in order to get a modern mix to work for test deps.