### PR TITLE
Simplify the response handling.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,24 +1,3 @@
-# This file is responsible for configuring your application and
-# its dependencies. It must return a keyword list containing the
-# application name and have as value another keyword list with
-# the application key-value pairs.
+use Mix.Config
 
-# Note this configuration is loaded before any dependency and is
-# restricted to this project. If another project depends on this
-# project, this file won't be loaded nor affect the parent project.
-
-# You can customize the configuration path by setting :config_path
-# in your mix.exs file. For example, you can emulate configuration
-# per environment by setting:
-#
-#     config_path: "config/#{Mix.env}.exs"
-#
-# Changing any file inside the config directory causes the whole
-# project to be recompiled.
-
-# Sample configuration:
-#
-# [dep1: [key: :value],
-#  dep2: [key: :value]]
-
-[]
+import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,16 @@
+use Mix.Config
+
+provider_router_port = 4999
+consumer_router_port = 4998
+
+config :oauth2,
+  client_id: "client_id",
+  client_secret: "client_secret",
+  site: "http://localhost:#{provider_router_port}",
+  redirect_uri: "http://localhost:#{consumer_router_port}/auth/callback"
+
+config :oauth2, ProviderRouter,
+  port: provider_router_port
+
+config :oauth2, ConsumerRouter,
+  port: consumer_router_port

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,16 @@
+use Mix.Config
+
+provider_router_port = 4999
+consumer_router_port = 4998
+
+config :oauth2,
+  client_id: "client_id",
+  client_secret: "client_secret",
+  site: "http://localhost:#{provider_router_port}",
+  redirect_uri: "http://localhost:#{consumer_router_port}/auth/callback"
+
+config :oauth2, ProviderRouter,
+  port: provider_router_port
+
+config :oauth2, ConsumerRouter,
+  port: consumer_router_port

--- a/lib/oauth2/access_token.ex
+++ b/lib/oauth2/access_token.ex
@@ -101,9 +101,12 @@ defmodule OAuth2.AccessToken do
   Makes a request of given type to the given URL using the AccessToken.
   """
   def request(method, token, url, body \\ "", headers \\ [], opts \\ []) do
-    case Request.request(method, process_url(token, url), body, req_headers(token, headers), opts) do
-      {:ok, response} -> {:ok, response.body}
-      {:error, reason} -> {:error, %Error{reason: reason}}
+    url = process_url(token, url)
+    headers = req_headers(token, headers)
+
+    case Request.request(method, url, body, headers, opts) do
+      {:ok, response} -> {:ok, response}
+      {:error, error} -> {:error, error}
     end
   end
 
@@ -114,7 +117,7 @@ defmodule OAuth2.AccessToken do
   error tuple (`{:error, reason}`).
   """
   def request!(method, token, url, body \\ "", headers \\ [], opts \\ []) do
-    case Request.request(method, process_url(token, url), body, req_headers(token, headers), opts) do
+    case request(method, token, url, body, headers, opts) do
       {:ok, response} -> response
       {:error, error} -> raise error
     end

--- a/lib/oauth2/access_token.ex
+++ b/lib/oauth2/access_token.ex
@@ -55,7 +55,8 @@ defmodule OAuth2.AccessToken do
   @doc """
   Makes a `GET` request to the given URL using the AccessToken.
   """
-  def get(token, url, headers \\ [], opts \\ []), do: request(:get, token, url, headers, opts)
+  def get(token, url, headers \\ [], opts \\ []),
+    do: request(:get, token, url, headers, opts)
 
   @doc """
   Makes a `GET` request to the given URL using the AccessToken.
@@ -63,12 +64,14 @@ defmodule OAuth2.AccessToken do
   An `OAuth2.Error` exception is raised if the request results in an
   error tuple (`{:error, reason}`).
   """
-  def get!(token, url, headers \\ [], opts \\ []), do: request!(:get, token, url, headers, opts)
+  def get!(token, url, headers \\ [], opts \\ []),
+    do: request!(:get, token, url, headers, opts)
 
   @doc """
   Makes a `PUT` request to the given URL using the AccessToken.
   """
-  def put(token, url, body \\ "", headers \\ [], opts \\ []), do: request(:put, token, url, body, headers, opts)
+  def put(token, url, body \\ "", headers \\ [], opts \\ []),
+    do: request(:put, token, url, body, headers, opts)
 
   @doc """
   Makes a `PUT` request to the given URL using the AccessToken.
@@ -76,12 +79,14 @@ defmodule OAuth2.AccessToken do
   An `OAuth2.Error` exception is raised if the request results in an
   error tuple (`{:error, reason}`).
   """
-  def put!(token, url, body \\ "", headers \\ [], opts \\ []), do: request!(:put, token, url, body, headers, opts)
+  def put!(token, url, body \\ "", headers \\ [], opts \\ []),
+    do: request!(:put, token, url, body, headers, opts)
 
   @doc """
   Makes a `POST` request to the given URL using the AccessToken.
   """
-  def post(token, url, body \\ "", headers \\ [], opts \\ []), do: request(:post, token, url, body, headers, opts)
+  def post(token, url, body \\ "", headers \\ [], opts \\ []),
+    do: request(:post, token, url, body, headers, opts)
 
   @doc """
   Makes a `POST` request to the given URL using the AccessToken.
@@ -89,7 +94,8 @@ defmodule OAuth2.AccessToken do
   An `OAuth2.Error` exception is raised if the request results in an
   error tuple (`{:error, reason}`).
   """
-  def post!(token, url, body \\ "", headers \\ [], opts \\ []), do: request!(:post, token, url, body, headers, opts)
+  def post!(token, url, body \\ "", headers \\ [], opts \\ []),
+    do: request!(:post, token, url, body, headers, opts)
 
   @doc """
   Makes a request of given type to the given URL using the AccessToken.

--- a/lib/oauth2/access_token.ex
+++ b/lib/oauth2/access_token.ex
@@ -5,7 +5,6 @@ defmodule OAuth2.AccessToken do
 
   import OAuth2.Util
 
-  alias OAuth2.Error
   alias OAuth2.Client
   alias OAuth2.Request
   alias OAuth2.AccessToken

--- a/lib/oauth2/request.ex
+++ b/lib/oauth2/request.ex
@@ -3,15 +3,19 @@ defmodule OAuth2.Request do
 
   use HTTPoison.Base
 
+  import OAuth2.Util
+
   alias OAuth2.Error
   alias OAuth2.Response
 
   def request(method, url, body \\ "", headers \\ [], opts \\ []) do
-    content_type = OAuth2.Util.content_type(headers)
-    url = process_url(to_string(url))
-    body = process_request_body(body, content_type)
-    headers = process_request_headers(headers, content_type)
-    :hackney.request(method, url, headers, body, opts) |> do_request
+    body = process_request_body(body, content_type(headers))
+    case super(method, url, body, headers, opts) do
+      {:ok, %HTTPoison.Response{status_code: status, headers: headers, body: body}} ->
+        {:ok, Response.new(status, headers, body)}
+      {:error, %HTTPoison.Error{reason: reason}} ->
+        {:ok, %Error{reason: reason}}
+    end
   end
 
   def request!(method, url, body \\ "", headers \\ [], options \\ []) do
@@ -25,22 +29,7 @@ defmodule OAuth2.Request do
     [{"Accept", content_type} | headers]
 
   defp process_request_body("", _), do: ""
-  defp process_request_body(body, "application/json"), do:
-    Poison.encode!(body)
+  defp process_request_body(body, "application/json"), do: Poison.encode!(body)
   defp process_request_body(body, "application/x-www-form-urlencoded"), do:
     Plug.Conn.Query.encode(body)
-
-  defp do_request({:ok, status_code, headers, _client}) when status_code in [204, 304], do:
-    {:ok, Response.new(status_code, headers, "")}
-  defp do_request({:ok, status_code, headers}), do:
-    {:ok, Response.new(status_code, headers, "")}
-  defp do_request({:ok, status_code, headers, client}), do:
-    handle_request_body(:hackney.body(client), status_code, headers)
-  defp do_request({:error, reason}), do:
-    {:error, %Error{reason: reason}}
-
-  defp handle_request_body({:ok, body}, status_code, headers), do:
-    {:ok, Response.new(status_code, headers, body)}
-  defp handle_request_body({:error, reason}, _status_code, _headers), do:
-    {:error, %Error{reason: reason}}
 end

--- a/lib/oauth2/request.ex
+++ b/lib/oauth2/request.ex
@@ -9,7 +9,10 @@ defmodule OAuth2.Request do
   alias OAuth2.Response
 
   def request(method, url, body \\ "", headers \\ [], opts \\ []) do
-    body = process_request_body(body, content_type(headers))
+    content_type = content_type(headers)
+    body = process_request_body(body, content_type)
+    headers = process_request_headers(headers, content_type)
+
     case super(method, url, body, headers, opts) do
       {:ok, %HTTPoison.Response{status_code: status, headers: headers, body: body}} ->
         {:ok, Response.new(status, headers, body)}

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule OAuth2.Mixfile do
      {:plug, "~> 1.0"},
 
      # Test dependencies
-     {:cowboy, "~> 1.0"},
+     {:cowboy, "~> 1.0", optional: true},
      {:excoveralls, "~> 0.3", only: :test},
 
      # Docs dependencies

--- a/mix.exs
+++ b/mix.exs
@@ -7,6 +7,7 @@ defmodule OAuth2.Mixfile do
      elixir: "~> 1.0",
      deps: deps,
      package: package,
+     elixirc_paths: elixirc_paths(Mix.env),
      name: "OAuth2",
      description: "An Elixir OAuth 2.0 Client Library",
      source_url: "https://github.com/scrogson/oauth2",
@@ -38,4 +39,7 @@ defmodule OAuth2.Mixfile do
      licenses: ["MIT"],
      links: %{github: "https://github.com/scrogson/oauth2"}]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 end

--- a/mix.exs
+++ b/mix.exs
@@ -16,17 +16,16 @@ defmodule OAuth2.Mixfile do
   end
 
   def application do
-    [applications: [:httpoison]]
+    [applications: [:httpoison, :poison, :plug]]
   end
 
   defp deps do
-    [{:hackney, "~> 1.0"},
-     {:httpoison, "~> 0.6"},
+    [{:httpoison, "~> 0.7"},
      {:poison, "~> 1.3"},
      {:plug, "~> 1.0"},
 
      # Test dependencies
-     {:cowboy, "~> 1.0", only: :test},
+     {:cowboy, "~> 1.0"},
      {:excoveralls, "~> 0.3", only: :test},
 
      # Docs dependencies

--- a/mix.lock
+++ b/mix.lock
@@ -4,11 +4,11 @@
   "ex_doc": {:hex, :ex_doc, "0.8.4"},
   "excoveralls": {:hex, :excoveralls, "0.3.11"},
   "exjsx": {:hex, :exjsx, "3.2.0"},
-  "hackney": {:hex, :hackney, "1.0.6"},
-  "httpoison": {:hex, :httpoison, "0.6.2"},
+  "hackney": {:hex, :hackney, "1.3.2"},
+  "httpoison": {:hex, :httpoison, "0.7.4"},
   "idna": {:hex, :idna, "1.0.2"},
   "jsx": {:hex, :jsx, "2.6.2"},
   "plug": {:hex, :plug, "1.0.0"},
   "poison": {:hex, :poison, "1.3.1"},
   "ranch": {:hex, :ranch, "1.1.0"},
-  "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.1"}}
+  "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"}}

--- a/test/oauth2/access_token_test.exs
+++ b/test/oauth2/access_token_test.exs
@@ -16,6 +16,18 @@ defmodule OAuth2.AccessTokenTest do
     assert token.other_params == %{"expires" => "123"}
   end
 
+  test "get success" do
+    token = build_client() |> build_token()
+    {:ok, result} = AccessToken.get(token, "/api/success.json")
+    assert result.body["data"] == "success!"
+  end
+
+  test "get error" do
+    token = build_client() |> build_token()
+    {:ok, result} = AccessToken.get(token, "/api/error.json")
+    assert result.body["error"] == "oh noes!"
+  end
+
   test "expires?" do
     assert AccessToken.expires?(%AccessToken{expires_at: 0})
     refute AccessToken.expires?(%AccessToken{expires_at: nil})

--- a/test/oauth2/access_token_test.exs
+++ b/test/oauth2/access_token_test.exs
@@ -1,10 +1,18 @@
 defmodule OAuth2.AccessTokenTest do
   use ExUnit.Case, async: true
+  use Plug.Test
+
+  import OAuth2.TestHelpers
 
   alias OAuth2.Client
   alias OAuth2.Response
   alias OAuth2.AccessToken
   alias OAuth2.Strategy.AuthCode
+
+  test "new from binary token" do
+    token = AccessToken.new("abc123", %Client{})
+    assert token.access_token == "abc123"
+  end
 
   test "new with 'expires' param" do
     response = Response.new(200, [{"Content-Type", "text/plain"}], "access_token=abc123&expires=123")

--- a/test/oauth2/strategy/client_credentials_test.exs
+++ b/test/oauth2/strategy/client_credentials_test.exs
@@ -3,33 +3,28 @@ defmodule OAuth2.Strategy.ClientCredentialsTest do
 
   alias OAuth2.Strategy.ClientCredentials
   import OAuth2.Client
+  import OAuth2.TestHelpers
 
-  @opts [
-    strategy: ClientCredentials,
-    client_id: "client_id",
-    client_secret: "secret",
-    site: "https://auth.example.com",
-    redirect_uri: "http://localhost/auth/callback"
-  ]
+  @client build_client(strategy: ClientCredentials)
 
   test "new" do
-    client = OAuth2.new(@opts)
+    client = @client
     assert client.client_id     == "client_id"
-    assert client.client_secret == "secret"
-    assert client.site          == "https://auth.example.com"
+    assert client.client_secret == "client_secret"
+    assert client.site          == "http://localhost:4999"
     assert client.authorize_url == "/oauth/authorize"
     assert client.token_url     == "/oauth/token"
-    assert client.redirect_uri  == "http://localhost/auth/callback"
+    assert client.redirect_uri  == "http://localhost:4998/auth/callback"
   end
 
   test "authorize_url" do
     assert_raise RuntimeError, "Not implemented.", fn ->
-      OAuth2.new(@opts) |> authorize_url()
+      authorize_url(@client)
     end
   end
 
   test "get_token: auth_scheme defaults to 'auth_header'" do
-    client = OAuth2.new(@opts)
+    client = @client
     client = ClientCredentials.get_token(client, [], [])
     base64 = Base.encode64(client.client_id <> ":" <> client.client_secret)
     assert client.headers == [{"Authorization", "Basic #{base64}"}]
@@ -37,7 +32,7 @@ defmodule OAuth2.Strategy.ClientCredentialsTest do
   end
 
   test "get_token: with auth_scheme set to 'request_body'" do
-    client = OAuth2.new(@opts)
+    client = @client
     client = ClientCredentials.get_token(client, [auth_scheme: "request_body"], [])
     assert client.headers == []
     assert client.params["grant_type"] == "client_credentials"

--- a/test/oauth2/strategy/password_test.exs
+++ b/test/oauth2/strategy/password_test.exs
@@ -3,33 +3,28 @@ defmodule OAuth2.Strategy.PasswordTest do
 
   alias OAuth2.Strategy.Password
   import OAuth2.Client
+  import OAuth2.TestHelpers
 
-  @opts [
-    strategy: Password,
-    client_id: "client_id",
-    client_secret: "secret",
-    site: "https://auth.example.com",
-    redirect_uri: "http://localhost/auth/callback"
-  ]
+  @client build_client(strategy: Password)
 
   test "new" do
-    client = OAuth2.new(@opts)
+    client = @client
     assert client.client_id     == "client_id"
-    assert client.client_secret == "secret"
-    assert client.site          == "https://auth.example.com"
+    assert client.client_secret == "client_secret"
+    assert client.site          == "http://localhost:4999"
     assert client.authorize_url == "/oauth/authorize"
     assert client.token_url     == "/oauth/token"
-    assert client.redirect_uri  == "http://localhost/auth/callback"
+    assert client.redirect_uri  == "http://localhost:4998/auth/callback"
   end
 
   test "authorize_url" do
     assert_raise RuntimeError, "Not implemented.", fn ->
-      OAuth2.new(@opts) |> authorize_url()
+      authorize_url(@client)
     end
   end
 
   test "get_token when username and password given in params" do
-    client = OAuth2.new(@opts)
+    client = @client
     client = Password.get_token(client, [username: "scrogson", password: "password"], [])
     assert client.params["username"] == "scrogson"
     assert client.params["password"] == "password"
@@ -40,7 +35,7 @@ defmodule OAuth2.Strategy.PasswordTest do
 
   test "get_token when username and password updated via put_param" do
     client =
-      OAuth2.new(@opts)
+      @client
       |> put_param(:username, "scrogson")
       |> put_param(:password, "password")
       |> Password.get_token([], [])
@@ -51,7 +46,7 @@ defmodule OAuth2.Strategy.PasswordTest do
 
   test "get_token when username and password are not provided" do
     assert_raise RuntimeError, "Missing required keys `username` and `password` for OAuth2.Strategy.Password", fn ->
-      OAuth2.new(@opts) |> Password.get_token([], [])
+      Password.get_token(@client, [], [])
     end
   end
 end

--- a/test/oauth2_test.exs
+++ b/test/oauth2_test.exs
@@ -1,9 +1,25 @@
 defmodule OAuth2Test do
   use ExUnit.Case
+  import OAuth2.TestHelpers
 
-  @opts [site: "http://localhost", redirect_uri: "http://localhost/auth/callback"]
-  test "`new` delegates to `OAuth2.Client`" do
-    client = OAuth2.new(@opts)
+  @client build_client(client_id: "abc123",
+                     client_secret: "xyz987",
+                     site: "https://api.github.com",
+                     redirect_uri: "http://localhost/auth/callback")
+
+  test "`new` delegates to `OAuth2.Client.new/1`" do
+    client = @client
     assert client.strategy == OAuth2.Strategy.AuthCode
+    assert client.site == "https://api.github.com"
+    assert client.client_id == "abc123"
+    assert client.client_secret == "xyz987"
+    assert client.site == "https://api.github.com"
+    assert client.authorize_url == "/oauth/authorize"
+    assert client.token_url == "/oauth/token"
+    assert client.token_method == :post
+    assert client.params == %{}
+    assert client.headers == []
+    assert client.redirect_uri == "http://localhost/auth/callback"
   end
 end
+

--- a/test/support/consumer_router.ex
+++ b/test/support/consumer_router.ex
@@ -1,0 +1,38 @@
+defmodule ConsumerRouter do
+  use Plug.Router
+  import Plug.Conn
+  import OAuth2.TestHelpers
+
+  plug Plug.Parsers,
+    parsers: [:urlencoded, :multipart, :json],
+    pass: ["*/*"],
+    json_decoder: Poison
+
+  plug :put_oauth2_client
+  plug :match
+  plug :dispatch
+
+  get "/auth" do
+    conn
+    |> put_resp_header("location", OAuth2.Client.authorize_url!(client(conn)))
+    |> send_resp(302, "")
+  end
+
+  get "/auth/callback" do
+    token = OAuth2.Client.get_token!(client(conn), code: conn.params["code"])
+    send self, token
+    conn
+  end
+
+  get "/" do
+    conn
+    |> send_resp(200, "Hello world")
+  end
+
+  defp client(conn), do: conn.private.oauth2_client
+
+  def put_oauth2_client(conn, _) do
+    conn
+    |> put_private(:oauth2_client, build_client())
+  end
+end

--- a/test/support/provider_router.ex
+++ b/test/support/provider_router.ex
@@ -1,0 +1,38 @@
+defmodule ProviderRouter do
+  use Plug.Router
+  import Plug.Conn
+
+  plug Plug.Parsers,
+    parsers: [:urlencoded, :multipart, :json],
+    pass: ["*/*"],
+    json_decoder: Poison
+
+  plug :match
+  plug :dispatch
+
+  get "/oauth/authorize" do
+    redirect_uri = conn.params["redirect_uri"]
+    conn
+    |> put_resp_header("location", redirect_uri <> "?" <> "code=1234")
+    |> send_resp(302, "")
+  end
+
+  post "/oauth/token" do
+    token = %{expires_in: 3600, access_token: "abc123", token_type: "bearer"}
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(200, Poison.encode!(token))
+  end
+
+  get "/api/success.json" do
+    conn
+    |> put_resp_header("content-type", "application/json")
+    |> send_resp(200, "{\"data\": \"success!\"}")
+  end
+
+  get "/api/error.json" do
+    conn
+    |> put_resp_header("content-type", "application/json")
+    |> send_resp(406, "{\"error\": \"oh noes!\"}")
+  end
+end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -1,0 +1,45 @@
+defmodule OAuth2.TestHelpers do
+
+  def call(mod, conn) do
+    mod.call(conn, [])
+  end
+
+  def build_client(opts \\ []) do
+    default_client_opts
+    |> Keyword.merge(opts)
+    |> OAuth2.Client.new()
+  end
+
+  def build_token(opts \\ [], %OAuth2.Client{} = client) do
+    default_token_opts
+    |> Keyword.merge(opts)
+    |> stringify_keys()
+    |> OAuth2.AccessToken.new(client)
+  end
+
+  defp get_config(key) do
+    case Application.get_env(:oauth2, key) do
+      {:system, val} -> System.get_env(val)
+      val -> val
+    end
+  end
+
+  defp default_client_opts do
+    [client_id: get_config(:client_id),
+     client_secret: get_config(:client_secret),
+     site: get_config(:site),
+     redirect_uri: get_config(:redirect_uri)]
+  end
+
+  defp default_token_opts do
+    [access_token: "abcdefgh",
+     expires_at: OAuth2.Util.unix_now + 600,
+     token_type: "Bearer"]
+  end
+
+  defp stringify_keys(dict) do
+    dict
+    |> Enum.map(fn {k,v} -> {Atom.to_string(k), v} end)
+    |> Enum.into(%{})
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,70 +1,7 @@
 ExUnit.start
 
-defmodule Provider do
-  use Plug.Router
-  import Plug.Conn
+provider_opts = Application.get_env(:oauth2, ProviderRouter)
+consumer_opts = Application.get_env(:oauth2, ConsumerRouter)
 
-  plug Plug.Parsers, parsers: [:urlencoded, :multipart]
-
-  plug :match
-  plug :dispatch
-
-  get "/oauth/authorize" do
-    redirect_uri = conn.params["redirect_uri"]
-    conn
-    |> put_resp_header("location", redirect_uri <> "?" <> "code=1234")
-    |> send_resp(302, "")
-  end
-
-  post "/oauth/token" do
-    token = %{expires_in: 3600, access_token: "abc123", token_type: "bearer"}
-    conn
-    |> put_resp_content_type("application/json")
-    |> send_resp(200, Poison.encode!(token))
-  end
-end
-
-defmodule Client do
-  use Plug.Router
-  import Plug.Conn
-
-  @opts [
-    client_id: "client_id",
-    client_secret: "secret",
-    site: "http://localhost:4999",
-    redirect_uri: "http://localhost:4998/auth/callback"
-  ]
-
-  plug Plug.Parsers, parsers: [:urlencoded, :multipart]
-
-  plug :put_oauth2_client
-  plug :match
-  plug :dispatch
-
-  get "/me" do
-    conn
-  end
-
-  get "/auth" do
-    conn
-    |> put_resp_header("location", OAuth2.Client.authorize_url!(client(conn)))
-    |> send_resp(302, "")
-  end
-
-  get "/auth/callback" do
-    token = OAuth2.Client.get_token!(client(conn), code: conn.params["code"])
-    send self, token
-    conn
-  end
-
-  get "/" do
-    conn
-  end
-
-  defp client(conn), do: conn.private.oauth2_client
-
-  def put_oauth2_client(conn, _) do
-    put_private(conn, :oauth2_client, OAuth2.new(@opts))
-  end
-end
-
+Plug.Adapters.Cowboy.http ProviderRouter, [], provider_opts
+Plug.Adapters.Cowboy.http ConsumerRouter, [], consumer_opts


### PR DESCRIPTION
This PR improves the ability to pattern match on the results coming back from a provider.

Previously, you would only get back the body. Now you will get back an `{:ok, %OAuth2.Response{}}`.

So you can do something like:


```elixir
case OAuth2.AccessToken.get(token, "/me") do
  {:ok, %OAuth2.Response{status: 401}} ->
    # the token is probably expired. Get a new one
  ...
end
```