### PR TITLE
params is map and key is string on phoenix framework v1.1.1

### DIFF
--- a/lib/oauth2/strategy/auth_code.ex
+++ b/lib/oauth2/strategy/auth_code.ex
@@ -42,7 +42,10 @@ defmodule OAuth2.Strategy.AuthCode do
   Retrieve an access token given the specified validation code.
   """
   def get_token(client, params, headers) do
-    {code, params} = Keyword.pop(params, :code, client.params["code"])
+    {code, params} = case params do
+      ps when is_list(ps) -> Keyword.pop(ps, :code, client.params["code"])
+      ps when is_map(ps) -> Map.pop(ps, "code", client.params["code"])
+    end
 
     unless code do
       raise OAuth2.Error, reason: "Missing required key `code` for `#{inspect __MODULE__}`"

--- a/lib/oauth2/strategy/client_credentials.ex
+++ b/lib/oauth2/strategy/client_credentials.ex
@@ -28,7 +28,10 @@ defmodule OAuth2.Strategy.ClientCredentials do
   Retrieve an access token given the specified strategy.
   """
   def get_token(client, params, headers) do
-    {auth_scheme, params} = Keyword.pop(params, :auth_scheme, "auth_header")
+    {auth_scheme, params} = case params do
+      ps when is_list(ps) -> Keyword.pop(ps, :auth_scheme, "auth_header")
+      ps when is_map(ps) -> Map.pop(ps, "auth_scheme", "auth_header")
+    end
 
     client
     |> put_param(:grant_type, "client_credentials")

--- a/lib/oauth2/strategy/password.ex
+++ b/lib/oauth2/strategy/password.ex
@@ -33,8 +33,18 @@ defmodule OAuth2.Strategy.Password do
   Retrieve an access token given the specified End User username and password.
   """
   def get_token(client, params, headers) do
-    {username, params} = Keyword.pop(params, :username, client.params["username"])
-    {password, params} = Keyword.pop(params, :password, client.params["password"])
+    {username, params} = case params do
+      ps when is_list(ps) ->
+        Keyword.pop(ps, :username, client.params["username"])
+      ps when is_map(ps) ->
+        Map.pop(ps, "username", client.params["username"])
+    end
+    {password, params} = case params do
+      ps when is_list(ps) ->
+        Keyword.pop(ps, :password, client.params["password"])
+      ps when is_map(ps) ->
+        Map.pop(ps, "password", client.params["password"])
+    end
 
     unless username && password do
       raise OAuth2.Error, reason: "Missing required keys `username` and `password` for #{inspect __MODULE__}"

--- a/test/oauth2/strategy/auth_code_test.exs
+++ b/test/oauth2/strategy/auth_code_test.exs
@@ -47,6 +47,9 @@ defmodule OAuth2.Strategy.AuthCodeTest do
 
     assert {:ok, %AccessToken{} = token} = Client.get_token(client, [code: code])
     assert token.access_token == access_token
+
+    assert {:ok, %AccessToken{} = token} = Client.get_token(client, %{"code" => code})
+    assert token.access_token == access_token
   end
 
   test "get_token throws and error if there is no 'code' param" do

--- a/test/oauth2/strategy/client_credentials_test.exs
+++ b/test/oauth2/strategy/client_credentials_test.exs
@@ -31,4 +31,12 @@ defmodule OAuth2.Strategy.ClientCredentialsTest do
     assert client.params["client_id"] == client.client_id
     assert client.params["client_secret"] == client.client_secret
   end
+
+  test "get_token: when params is map", %{client: client} do
+    client = ClientCredentials.get_token(client, %{"auth_scheme" => "request_body"}, [])
+    assert client.headers == []
+    assert client.params["grant_type"] == "client_credentials"
+    assert client.params["client_id"] == client.client_id
+    assert client.params["client_secret"] == client.client_secret
+  end
 end

--- a/test/oauth2/strategy/password_test.exs
+++ b/test/oauth2/strategy/password_test.exs
@@ -25,6 +25,15 @@ defmodule OAuth2.Strategy.PasswordTest do
     assert client.params["client_secret"] == client.client_secret
   end
 
+  test "get_token when params is map", %{client: client} do
+    client = Password.get_token(client, %{"username" => "scrogson", "password" => "password"}, [])
+    assert client.params["username"] == "scrogson"
+    assert client.params["password"] == "password"
+    assert client.params["grant_type"] == "password"
+    assert client.params["client_id"] == client.client_id
+    assert client.params["client_secret"] == client.client_secret
+  end
+
   test "get_token when username and password updated via put_param", %{client: client} do
     client =
       client


### PR DESCRIPTION
I needed to convert map to keyword list and atom to string when using get_token! on phoenix framework.
like this:
```
  def get_token!(params \\ [], headers \\ [], options \\ []) do
    kl_params = Enum.map(params, fn {k,v} -> {String.to_atom(k), v} end)
    OAuth2.Client.get_token!(client(), kl_params, headers, options)
  end
```
This workaround becomes useless by this patch.