### PR TITLE
Access token sending two Authentication headers

### DIFF
--- a/lib/oauth2/access_token.ex
+++ b/lib/oauth2/access_token.ex
@@ -117,7 +117,7 @@ defmodule OAuth2.AccessToken do
       expires_at:    (std["expires_in"] || other["expires"]) |> expires_at(),
       token_type:    std["token_type"] |> normalize_token_type(),
       other_params:  other,
-      client:        client]
+      client:        remove_headers(client)]
   end
 
   @doc """
@@ -312,5 +312,9 @@ defmodule OAuth2.AccessToken do
 
   defp req_headers(token, headers) do
     [{"Authorization", "#{token.token_type} #{token.access_token}"} | headers] ++ token.client.headers
+  end
+
+  defp remove_headers(client) do
+    %{ client | headers: []}
   end
 end

--- a/test/oauth2/strategy/client_credentials_test.exs
+++ b/test/oauth2/strategy/client_credentials_test.exs
@@ -1,8 +1,9 @@
 defmodule OAuth2.Strategy.ClientCredentialsTest do
   use ExUnit.Case, async: true
+  use Plug.Test
 
   alias OAuth2.Strategy.ClientCredentials
-  import OAuth2.Client
+  alias OAuth2.Client
   import OAuth2.TestHelpers
 
   setup do
@@ -13,14 +14,25 @@ defmodule OAuth2.Strategy.ClientCredentialsTest do
 
   test "authorize_url", %{client: client} do
     assert_raise OAuth2.Error, ~r/This strategy does not implement/, fn ->
-      authorize_url(client)
+      Client.authorize_url(client)
     end
   end
 
-  test "get_token: auth_scheme defaults to 'auth_header'", %{client: client} do
-    client = ClientCredentials.get_token(client, [], [])
+  test "get_token: auth_scheme defaults to 'auth_header'", %{client: client, server: server} do
     base64 = Base.encode64(client.client_id <> ":" <> client.client_secret)
-    assert client.headers == [{"Authorization", "Basic #{base64}"}]
+    token_bearer = "123456=="
+    Bypass.expect server, fn conn ->
+      assert get_req_header(conn, "Authorization"), "Basic #{base64}"
+
+      send_resp conn, 200, ~s({"access_token": "#{token_bearer}", "token_type": "bearer", "expires_in": "999" })
+    end
+
+    token = Client.get_token!(client)
+    client = token.client
+
+    # should not include on client response header
+    assert List.keyfind(client.headers, "Authorization", 0) == nil
+    assert token.access_token == token_bearer
     assert client.params["grant_type"] == "client_credentials"
   end
 

--- a/test/oauth2/strategy/client_credentials_test.exs
+++ b/test/oauth2/strategy/client_credentials_test.exs
@@ -18,22 +18,24 @@ defmodule OAuth2.Strategy.ClientCredentialsTest do
     end
   end
 
-  test "get_token: auth_scheme defaults to 'auth_header'", %{client: client, server: server} do
+  test "get_token: auth_scheme defaults to 'auth_header'", %{client: client} do
+    client = ClientCredentials.get_token(client, [], [])
     base64 = Base.encode64(client.client_id <> ":" <> client.client_secret)
-    token_bearer = "123456=="
+    assert client.headers == [{"Authorization", "Basic #{base64}"}]
+    assert client.params["grant_type"] == "client_credentials"
+  end
+
+  test "get_token: Duplicated auth_header ", %{client: client, server: server} do
     Bypass.expect server, fn conn ->
+      base64 = Base.encode64(client.client_id <> ":" <> client.client_secret)
       assert get_req_header(conn, "Authorization"), "Basic #{base64}"
 
-      send_resp conn, 200, ~s({"access_token": "#{token_bearer}", "token_type": "bearer", "expires_in": "999" })
+      send_resp conn, 200, ~s({"access_token": "123456==", "token_type": "bearer", "expires_in": "999" })
     end
-
     token = Client.get_token!(client)
     client = token.client
 
-    # should not include on client response header
     assert List.keyfind(client.headers, "Authorization", 0) == nil
-    assert token.access_token == token_bearer
-    assert client.params["grant_type"] == "client_credentials"
   end
 
   test "get_token: with auth_scheme set to 'request_body'", %{client: client} do


### PR DESCRIPTION
On normal flow from client credentials, the client is sending tow `Authorization` headers to my api client one with the correct `Bearer` content, other with the client header `Basic`, which was created to get the bearer token. This causes confusion on my API provider assumes the Basic token is the one that has to be validated causing an invalid type error.

Ex of my flow

```elixir
client = OAuth2.Client.new([
      strategy: OAuth2.Strategy.ClientCredentials,
      client_id: @client_id,
      client_secret: @client_secret,
      site: @site,
      token_url: @token_url
    ])
token = client.get_token!(client)
OAuth2.AccessToken.get!(token, "/users") # sending two Authorization headers
```