### PR TITLE
Allow poison ~> 2.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule OAuth2.Mixfile do
 
   defp deps do
     [{:httpoison, "~> 0.7"},
-     {:poison, "~> 1.3"},
+     {:poison, "~> 1.3 or ~> 2.0"},
      {:mimetype_parser, "~> 0.1"},
 
      # Test dependencies


### PR DESCRIPTION
Otherwise it breaks if any of your dependencies is using poison 2.0 or 2.1

I ran the tests with 2.1 and it passes.