### PR TITLE
Fixing version number in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ end
 
 defp deps do
   # Add the dependency
-  [{:oauth2, "~> 0.5"}]
+  [{:oauth2, "~> 0.6"}]
 end
 ```
 


### PR DESCRIPTION
Bump the version to 0.6 in the instructions on how to add a new dependency.