### PR TITLE
Parse expires_in to future timestamp

### DIFF
--- a/lib/oauth2/access_token.ex
+++ b/lib/oauth2/access_token.ex
@@ -108,7 +108,7 @@ defmodule OAuth2.AccessToken do
     struct(AccessToken, [
       access_token:  std["access_token"],
       refresh_token: std["refresh_token"],
-      expires_at:    (std["expires_in"] || other["expires"]) |> expires_at(),
+      expires_at:    (std["expires_in"] |> expires_at) || (other["expires"] |> expires),
       token_type:    std["token_type"] |> normalize_token_type(),
       other_params:  other
     ])
@@ -135,10 +135,23 @@ defmodule OAuth2.AccessToken do
   """
   def expires_at(nil), do: nil
   def expires_at(val) when is_binary(val) do
-    {int, _} = Integer.parse(val)
-    int
+    val
+    |> Integer.parse
+    |> elem(0)
+    |> expires_at
   end
   def expires_at(int), do: unix_now + int
+
+  @doc """
+  Returns the expires value as an integer
+  """
+  def expires(nil), do: nil
+  def expires(val) when is_binary(val) do
+    val
+    |> Integer.parse
+    |> elem(0)
+  end
+  def expires(int), do: int
 
   defp normalize_token_type(nil), do: "Bearer"
   defp normalize_token_type("bearer"), do: "Bearer"

--- a/test/oauth2/access_token_test.exs
+++ b/test/oauth2/access_token_test.exs
@@ -30,5 +30,12 @@ defmodule OAuth2.AccessTokenTest do
   test "expires_in" do
     assert AccessToken.expires_at(nil) == nil
     assert AccessToken.expires_at(3600) == OAuth2.Util.unix_now + 3600
+    assert AccessToken.expires_at("3600") == OAuth2.Util.unix_now + 3600
+  end
+
+  test "expires" do
+    assert AccessToken.expires(nil) == nil
+    assert AccessToken.expires(1469725602) == 1469725602
+    assert AccessToken.expires("1469725602") == 1469725602
   end
 end


### PR DESCRIPTION
This forces both string and integer values for expires in to parse to an
integer that is added to unix_now, while leaving expires to simply be
parsed to an integer.

Fixes #58 