### PR TITLE
Documentation Cleanup

### DIFF
--- a/lib/oauth2/access_token.ex
+++ b/lib/oauth2/access_token.ex
@@ -6,34 +6,6 @@ defmodule OAuth2.AccessToken do
 
   The `OAuth2.AccessToken` struct is created for you when you use the
   `OAuth2.Client.get_token`
-
-  ### Notes
-
-  * If a full url is given (e.g. "http://www.example.com/api/resource") then it
-  will use that otherwise you can specify an endpoint (e.g. "/api/resource") and
-  it will append it to the `Client.site`.
-
-  * The headers from the `Client.headers` are appended to the request headers.
-
-  ### Examples
-
-  ```
-  token =  OAuth2.AccessToken.new("abc123")
-
-  case OAuth2.AccessToken.get(token, "/some/resource") do
-    {:ok, %OAuth2.Response{status_code: 401}} ->
-      "Not Good"
-    {:ok, %OAuth2.Response{status_code: status_code, body: body}} when status_code in [200..299] ->
-      "Yay!!"
-    {:error, %OAuth2.Error{reason: reason}} ->
-      reason
-  end
-
-  response = OAuth2.AccessToken.get!(token, "/some/resource")
-
-  response = OAuth2.AccessToken.post!(token, "/some/other/resources", %{foo: "bar"})
-```
-
   """
 
   import OAuth2.Util
@@ -63,28 +35,7 @@ defmodule OAuth2.AccessToken do
             other_params: %{}
 
   @doc """
-  Returns a new `OAuth2.AccessToken` struct given the access token `string`.
-
-  ### Example
-
-  ```
-  iex(1)> OAuth2.AccessToken.new("abc123", %OAuth2.Client{})
-  %OAuth2.AccessToken{access_token: "abc123",
-   client: %OAuth2.Client{authorize_url: "/oauth/authorize", client_id: "",
-    client_secret: "", headers: [], params: %{}, redirect_uri: "", site: "",
-    strategy: OAuth2.Strategy.AuthCode, token_method: :post,
-    token_url: "/oauth/token"}, expires_at: nil, other_params: %{},
-   refresh_token: nil, token_type: "Bearer"}
-  ```
-
-  """
-  @spec new(binary) :: t
-  def new(token) when is_binary(token) do
-    new(%{"access_token" => token})
-  end
-
-  @doc """
-  Same as `new/2` except that the first arg is a `map`.
+  Returns a new `OAuth2.AccessToken` struct given the access token `string` or a response `map`.
 
   Note if giving a map, please be sure to make the key a `string` no an `atom`.
 
@@ -92,16 +43,17 @@ defmodule OAuth2.AccessToken do
 
   ### Example
 
-  ```
-  iex(1)> OAuth2.AccessToken.new(%{"access_token" => "abc123"}, %OAuth2.Client{})
-   %OAuth2.AccessToken{access_token: "abc123",
-    client: %OAuth2.Client{authorize_url: "/oauth/authorize", client_id: "",
-     client_secret: "", headers: [], params: %{}, redirect_uri: "", site: "",
-     strategy: OAuth2.Strategy.AuthCode, token_method: :post,
-     token_url: "/oauth/token"}, expires_at: nil, other_params: %{},
-    refresh_token: nil, token_type: "Bearer"}
-  ```
+      iex> OAuth2.AccessToken.new("abc123")
+      %OAuth2.AccessToken{access_token: "abc123", expires_at: nil, other_params: %{}, refresh_token: nil, token_type: "Bearer"}
+
+      iex> OAuth2.AccessToken.new(%{"access_token" => "abc123"})
+      %OAuth2.AccessToken{access_token: "abc123", expires_at: nil, other_params: %{}, refresh_token: nil, token_type: "Bearer"}
   """
+  @spec new(binary) :: t
+  def new(token) when is_binary(token) do
+    new(%{"access_token" => token})
+  end
+
   def new(response) when is_map(response) do
     {std, other} = Map.split(response, @standard)
 

--- a/lib/oauth2/client.ex
+++ b/lib/oauth2/client.ex
@@ -2,6 +2,34 @@ defmodule OAuth2.Client do
   @moduledoc """
   This module defines the `OAuth2.Client` struct and is responsible for building
   and establishing a request for an access token.
+
+  ### Notes
+
+  * If a full url is given (e.g. "http://www.example.com/api/resource") then it
+  will use that otherwise you can specify an endpoint (e.g. "/api/resource") and
+  it will append it to the `Client.site`.
+
+  * The headers from the `Client.headers` are appended to the request headers.
+
+  ### Examples
+
+  ```
+  client =  OAuth2.Client.new([{:token,"abc123"}])
+
+  case OAuth2.Client.get(client, "/some/resource") do
+  {:ok, %OAuth2.Response{status_code: 401}} ->
+  "Not Good"
+  {:ok, %OAuth2.Response{status_code: status_code, body: body}} when status_code in [200..299] ->
+  "Yay!!"
+  {:error, %OAuth2.Error{reason: reason}} ->
+  reason
+  end
+
+  response = OAuth2.Client.get!(client, "/some/resource")
+
+  response = OAuth2.Client.post!(client, "/some/other/resources", %{foo: "bar"})
+  ```
+
   """
 
   alias OAuth2.{AccessToken, Client, Error, Request}
@@ -67,6 +95,25 @@ defmodule OAuth2.Client do
     Defaults to `:post`
   * `token_url` - absolute or relative URL path to the token endpoint.
     Defaults to `"/oauth/token"`
+
+  ## Example
+
+  iex> OAuth2.Client.new([{:token, "123"}])
+  %OAuth2.Client{authorize_url: "/oauth/authorize", client_id: "",
+  client_secret: "", headers: [], params: %{}, redirect_uri: "", site: "",
+  strategy: OAuth2.Strategy.AuthCode,
+  token: %OAuth2.AccessToken{access_token: "123", expires_at: nil,
+  other_params: %{}, refresh_token: nil, token_type: "Bearer"},
+  token_method: :post, token_url: "/oauth/token"}
+
+  iex> token = OAuth2.AccessToken.new("123")
+  iex> OAuth2.Client.new([{:token, token}])
+  %OAuth2.Client{authorize_url: "/oauth/authorize", client_id: "",
+  client_secret: "", headers: [], params: %{}, redirect_uri: "", site: "",
+  strategy: OAuth2.Strategy.AuthCode,
+  token: %OAuth2.AccessToken{access_token: "123", expires_at: nil,
+  other_params: %{}, refresh_token: nil, token_type: "Bearer"},
+  token_method: :post, token_url: "/oauth/token"}
   """
   @spec new(t, Keyword.t) :: t
   def new(client \\ %Client{}, opts) do
@@ -133,7 +180,8 @@ defmodule OAuth2.Client do
 
   ## Example
 
-      redirect_url = OAuth2.Client.authorize_url!(%OAuth2.Client{})
+      iex> OAuth2.Client.authorize_url!(%OAuth2.Client{})
+      "/oauth/authorize?client_id=&redirect_uri=&response_type=code"
   """
   @spec authorize_url!(t, list) :: binary
   def authorize_url!(%Client{} = client, params \\ []) do

--- a/lib/oauth2/response.ex
+++ b/lib/oauth2/response.ex
@@ -1,7 +1,7 @@
 defmodule OAuth2.Response do
   @moduledoc """
   Defines the `OAuth2.Response` struct which is created from the HTTP responses
-  made by the `OAuth2.AccessToken` module.
+  made by the `OAuth2.Client` module.
 
   ## Struct fields
 

--- a/test/oauth2/access_token_test.exs
+++ b/test/oauth2/access_token_test.exs
@@ -1,5 +1,6 @@
 defmodule OAuth2.AccessTokenTest do
   use ExUnit.Case, async: true
+  doctest OAuth2.AccessToken
 
   alias OAuth2.{AccessToken, Response}
 

--- a/test/oauth2/client_test.exs
+++ b/test/oauth2/client_test.exs
@@ -1,6 +1,7 @@
 defmodule OAuth2.ClientTest do
   use ExUnit.Case, async: true
   use Plug.Test
+  doctest OAuth2.Client
 
   import OAuth2.Client
   import OAuth2.TestHelpers


### PR DESCRIPTION
Cleans up some documentation after the refactor in #52 .

I cleaned up some of the changes around the split out of the Client module. Documentation probably still needs to be written to migrate from 0.6 to 0.7.

I also added some doctests to make sure parts of the documentation stay up to date, feel free to remove them if you don't like them.

Related #60 