### PR TITLE
Documentation update for network timeout

### DIFF
--- a/lib/oauth2/client.ex
+++ b/lib/oauth2/client.ex
@@ -205,7 +205,7 @@ defmodule OAuth2.Client do
 
   ## Options
 
-  * `:timeout` - the timeout (in milliseconds) of the request
+  * `:recv_timeout` - the timeout (in milliseconds) of the request
   * `:proxy` - a proxy to be used for the request; it can be a regular url or a
    `{Host, Proxy}` tuple
   """


### PR DESCRIPTION
Per the docs for hackney (https://github.com/benoitc/hackney/blob/master/doc/hackney.md) the option for setting the timeout is `recv_timeout` instead of `timeout`