### PR TITLE
add the missing client_secret to AuthCode get_token

### DIFF
--- a/lib/oauth2/strategy/auth_code.ex
+++ b/lib/oauth2/strategy/auth_code.ex
@@ -52,6 +52,7 @@ defmodule OAuth2.Strategy.AuthCode do
     |> put_param(:code, code)
     |> put_param(:grant_type, "authorization_code")
     |> put_param(:client_id, client.client_id)
+    |> put_param(:client_secret, client.client_secret)
     |> put_param(:redirect_uri, client.redirect_uri)
     |> merge_params(params)
     |> put_headers(headers)


### PR DESCRIPTION
It seems that oauth 0.7.0 does not work with with Google it returns "Parameter not allowed for this message type: response_type", so I tried the master branch, but this time I got another error which is "client_secret is missing.", So I added the the missing client_secret param and it worked just fine