### PR TITLE
normalized expires and expires_in 

### DIFF
--- a/lib/oauth2/access_token.ex
+++ b/lib/oauth2/access_token.ex
@@ -60,7 +60,7 @@ defmodule OAuth2.AccessToken do
     struct(AccessToken, [
       access_token:  std["access_token"],
       refresh_token: std["refresh_token"],
-      expires_at:    (std["expires_in"] |> expires_at) || (other["expires"] |> expires),
+      expires_at:    (std["expires_in"] || other["expires"]) |> expires_at,
       token_type:    std["token_type"] |> normalize_token_type(),
       other_params:  other
     ])
@@ -93,17 +93,6 @@ defmodule OAuth2.AccessToken do
     |> expires_at
   end
   def expires_at(int), do: unix_now + int
-
-  @doc """
-  Returns the expires value as an integer
-  """
-  def expires(nil), do: nil
-  def expires(val) when is_binary(val) do
-    val
-    |> Integer.parse
-    |> elem(0)
-  end
-  def expires(int), do: int
 
   defp normalize_token_type(nil), do: "Bearer"
   defp normalize_token_type("bearer"), do: "Bearer"

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -26,6 +26,11 @@ defmodule OAuth2.TestHelpers do
     end
   end
 
+  def unix_now do
+    {mega, sec, _micro} = :os.timestamp
+    (mega * 1_000_000) + sec
+  end
+
   defp parse_req_body(conn) do
     opts = [parsers: [:urlencoded, :json],
             pass: ["*/*"],


### PR DESCRIPTION
Normalized `expires` and `expires_in` to act the same if present in a callback.

However I'm a bit confused if we really should do this.... Especially looking at the changes in tests. What do you guys think? 

And I think in case of Facebook not working correctly it was the case of using v1.0 version of their API. Right now I can see someone create a PR to use v2.8 and I guess there is a correct field `expires_in` being sent in a callback. (https://github.com/ueberauth/ueberauth_facebook/pull/27)