### PR TITLE
Fix compile time warnings with Elixir 1.4

### DIFF
--- a/lib/oauth2/access_token.ex
+++ b/lib/oauth2/access_token.ex
@@ -79,7 +79,7 @@ defmodule OAuth2.AccessToken do
   Determines if the access token has expired.
   """
   def expired?(token) do
-    expires?(token) && unix_now > token.expires_at
+    expires?(token) && unix_now() > token.expires_at
   end
 
   @doc """
@@ -92,7 +92,7 @@ defmodule OAuth2.AccessToken do
     |> elem(0)
     |> expires_at
   end
-  def expires_at(int), do: unix_now + int
+  def expires_at(int), do: unix_now() + int
 
   defp normalize_token_type(nil), do: "Bearer"
   defp normalize_token_type("bearer"), do: "Bearer"


### PR DESCRIPTION
I get that when compiling dependencies (that include oauth2) for a 1.4
warning: variable "unix_now" does not exist and is being expanded to "unix_now()", please use parentheses to remove the ambiguity or change the variable name
  lib/oauth2/access_token.ex:82

warning: variable "unix_now" does not exist and is being expanded to "unix_now()", please use parentheses to remove the ambiguity or change the variable name
  lib/oauth2/access_token.ex:95

