### PR TITLE
Raise exception when serializers configuration is missing

### DIFF
--- a/lib/oauth2/request.ex
+++ b/lib/oauth2/request.ex
@@ -3,7 +3,7 @@ defmodule OAuth2.Request do
 
   import OAuth2.Util
 
-  alias OAuth2.{Client, Error, Response}
+  alias OAuth2.{Client, Error, Response, Serializer}
 
   @type body :: any
 
@@ -75,11 +75,5 @@ defmodule OAuth2.Request do
   defp encode_request_body([], _), do: ""
   defp encode_request_body(body, "application/x-www-form-urlencoded"),
     do: URI.encode_query(body)
-  defp encode_request_body(body, type) do
-    if serializer = Application.get_env(:oauth2, :serializers)[type] do
-      serializer.encode!(body)
-    else
-      body
-    end
-  end
+  defp encode_request_body(body, type), do: Serializer.encode!(body, type)
 end

--- a/lib/oauth2/response.ex
+++ b/lib/oauth2/response.ex
@@ -12,6 +12,7 @@ defmodule OAuth2.Response do
 
   require Logger
   import OAuth2.Util
+  alias OAuth2.Serializer
 
   @type status_code :: integer
   @type headers     :: list
@@ -53,11 +54,5 @@ defmodule OAuth2.Response do
   end
   defp decode_response_body(body, "application/x-www-form-urlencoded"),
     do: URI.decode_query(body)
-  defp decode_response_body(body, type) do
-    if serializer = Application.get_env(:oauth2, :serializers)[type] do
-      serializer.decode!(body)
-    else
-      body
-    end
-  end
+  defp decode_response_body(body, type), do: Serializer.decode!(body, type)
 end

--- a/lib/oauth2/serializer.ex
+++ b/lib/oauth2/serializer.ex
@@ -1,0 +1,23 @@
+defmodule OAuth2.Serializer do
+  @moduledoc false
+
+  defmodule NullSerializer do
+    @moduledoc false
+    def decode!(content), do: content
+    def encode!(content), do: content
+  end
+
+  def decode!(content, type), do: serializer(type).decode!(content)
+  def encode!(content, type), do: serializer(type).encode!(content)
+
+  defp serializer(type) do
+    configured_serializers
+    |> Map.get(type, NullSerializer)
+  end
+
+  defp configured_serializers do
+    Application.get_env(:oauth2, :serializers) ||
+      raise("Missing serializers configuration! Make sure oauth2 app is added to mix application list")
+  end
+end
+

--- a/lib/oauth2/serializer.ex
+++ b/lib/oauth2/serializer.ex
@@ -11,7 +11,7 @@ defmodule OAuth2.Serializer do
   def encode!(content, type), do: serializer(type).encode!(content)
 
   defp serializer(type) do
-    configured_serializers
+    configured_serializers()
     |> Map.get(type, NullSerializer)
   end
 

--- a/test/serializer_test.exs
+++ b/test/serializer_test.exs
@@ -1,0 +1,39 @@
+defmodule OAuth2.SerializerTest do
+  use ExUnit.Case
+  import OAuth2.TestHelpers
+  alias OAuth2.Serializer
+
+  defmodule TestSerializer do
+    def decode!(_), do: "decode_ok"
+    def encode!(_), do: "encode_ok"
+  end
+  @json_mime "application/json"
+
+  def set_json_serializer(serializer) do
+    Application.put_env(:oauth2, :serializers, %{@json_mime => serializer})
+  end
+
+  test "has default json serializer" do
+    decoded = Serializer.decode!("{\"foo\": 1}", @json_mime)
+    assert decoded == %{"foo" => 1}
+  end
+
+  test "accepts serializer override" do
+    set_json_serializer(TestSerializer)
+
+    decoded = Serializer.decode!("{\"foo\": 1}", @json_mime)
+    assert decoded == "decode_ok"
+
+    encoded = Serializer.encode!(%{"foo" => 1}, @json_mime)
+    assert encoded == "encode_ok"
+  end
+
+  test "raise error when serializers are misconfigured" do
+    Application.put_env(:oauth2, :serializers, nil)
+
+    assert_raise(RuntimeError, ~r/configuration/i, fn ->
+      Serializer.decode!("{\"foo\": 1}", @json_mime)
+    end)
+  end
+end
+

--- a/test/serializer_test.exs
+++ b/test/serializer_test.exs
@@ -1,6 +1,5 @@
 defmodule OAuth2.SerializerTest do
   use ExUnit.Case
-  import OAuth2.TestHelpers
   alias OAuth2.Serializer
 
   defmodule TestSerializer do
@@ -9,8 +8,14 @@ defmodule OAuth2.SerializerTest do
   end
   @json_mime "application/json"
 
-  def set_json_serializer(serializer) do
-    Application.put_env(:oauth2, :serializers, %{@json_mime => serializer})
+  def with_serializers(serializers, fun) do
+    backup = Application.get_env(:oauth2, :serializers)
+    try do
+      Application.put_env(:oauth2, :serializers, serializers)
+      fun.()
+    after
+      Application.put_env(:oauth2, :serializers, backup)
+    end
   end
 
   test "has default json serializer" do
@@ -19,20 +24,20 @@ defmodule OAuth2.SerializerTest do
   end
 
   test "accepts serializer override" do
-    set_json_serializer(TestSerializer)
+    with_serializers(%{@json_mime => TestSerializer}, fn ->
+      decoded = Serializer.decode!("{\"foo\": 1}", @json_mime)
+      assert decoded == "decode_ok"
 
-    decoded = Serializer.decode!("{\"foo\": 1}", @json_mime)
-    assert decoded == "decode_ok"
-
-    encoded = Serializer.encode!(%{"foo" => 1}, @json_mime)
-    assert encoded == "encode_ok"
+      encoded = Serializer.encode!(%{"foo" => 1}, @json_mime)
+      assert encoded == "encode_ok"
+    end)
   end
 
   test "raise error when serializers are misconfigured" do
-    Application.put_env(:oauth2, :serializers, nil)
-
-    assert_raise(RuntimeError, ~r/configuration/i, fn ->
-      Serializer.decode!("{\"foo\": 1}", @json_mime)
+    with_serializers(nil, fn ->
+      assert_raise(RuntimeError, ~r/configuration/i, fn ->
+        Serializer.decode!("{\"foo\": 1}", @json_mime)
+      end)
     end)
   end
 end


### PR DESCRIPTION
Oauth2 silently ignores misconfigutration and just skips de/serialization of content. This lead me to long hours of debugging when all I needed was to add oauth2 application to the started applications in my mix file.
This pull request differentiate the case where a serializer for particular type is missing, indicated by a map without a value for that mime type and the case where the whole map is missing. If the whole map is missing it means something is not configured right, very likely oauth2 is missing from the mix file. Especially since this library can be a few of dependencies down, raising the misconfiguration problem as early as possible can help save time debugging.

