### PR TITLE
Fix dialyzer warning on @type params

### DIFF
--- a/lib/oauth2/client.ex
+++ b/lib/oauth2/client.ex
@@ -40,7 +40,7 @@ defmodule OAuth2.Client do
   @type client_secret :: binary
   @type headers       :: [{binary, binary}]
   @type param         :: binary | %{binary => param} | [param]
-  @type params        :: %{binary => param}
+  @type params        :: %{binary => param} | Keyword.t
   @type redirect_uri  :: binary
   @type site          :: binary
   @type strategy      :: module


### PR DESCRIPTION
Dialyzer complains about the `get_token/4` and `get_token!/4` functions, because the typespec says that the `params` argument is supposed to be a map with binary keys, whereas `OAuth2.Strategy.AuthCode.get_token/3` expects `params` to be a Keyword list.

Code:

```elixir
client()
|> OAuth2.Client.get_token!([code: code], [], [])
|> OAuth2.Client.get!("/user")
```

Dialyzer's complaint:

```
git_hub.ex:60: The call 'Elixir.OAuth2.Client':'get_token!'(#{'__struct__':='Elixir.OAuth2.Client', 'authorize_url':=binary(), 'client_id':=binary(), 'client_secret':=binary(), 'headers':=[{binary(),binary()}], 'params':=#{binary()=>binary() | [binary() | [any()] | map()] | #{binary()=>binary() | [any()] | map()}}, 'redirect_uri':=binary(), 'site':=binary(), 'strategy':=atom(), 'token':='nil' | #{'__struct__':='Elixir.OAuth2.AccessToken', 'access_token':=binary(), 'expires_at':=integer(), 'other_params':=#{}, 'refresh_token':=binary(), 'token_type':=binary()}, 'token_method':=atom(), 'token_url':=binary()},[{'code',_},...],[],[]) will never return since the success typing is (#{'__struct__':='Elixir.OAuth2.Client', 'authorize_url':=binary(), 'client_id':=binary(), 'client_secret':=binary(), 'headers':=[{binary(),binary()}], 'params':=#{binary()=>binary() | [binary() | [any()] | map()] | #{binary()=>binary() | [any()] | map()}}, 'redirect_uri':=binary(), 'site':=binary(), 'strategy':=atom(), 'token':='nil' | #{'__struct__':='Elixir.OAuth2.AccessToken', 'access_token':=binary(), 'expires_at':=integer(), 'other_params':=#{}, 'refresh_token':=binary(), 'token_type':=binary()}, 'token_method':=atom(), 'token_url':=binary()},#{binary()=>binary() | [binary() | [any()] | #{binary()=>_}] | #{binary()=>binary() | [any()] | #{binary()=>_}}},[{binary(),binary()}],[{atom(),_}]) -> #{'__struct__':='Elixir.OAuth2.Client', 'authorize_url':=binary(), 'client_id':=binary(), 'client_secret':=binary(), 'headers':=[], 'params':=#{}, 'redirect_uri':=binary(), 'site':=binary(), 'strategy':=atom(), 'token':=#{'__struct__':='Elixir.OAuth2.AccessToken', 'access_token':=binary(), 'expires_at':=integer(), 'other_params':=#{}, 'refresh_token':=binary(), 'token_type':=binary()}, 'token_method':=atom(), 'token_url':=binary()} and the contract is (t(),params(),headers(),'Elixir.Keyword':t()) -> 'Elixir.OAuth2.Client':t() | 'Elixir.OAuth2.Error':t()
```

If I change the code to make Dialyzer happy, it no longer functions:

```elixir
client()
|> OAuth2.Client.get_token!(%{"code" => code}, [], [])
|> OAuth2.Client.get!("/user")
```

However, with this typespec change, everything works fine.