### PR TITLE
Fix handling of Content-Types with multiple params

### DIFF
--- a/lib/oauth2/util.ex
+++ b/lib/oauth2/util.ex
@@ -18,10 +18,8 @@ defmodule OAuth2.Util do
   end
 
   defp remove_params(binary) do
-    case String.split(binary, ";") do
-      [content_type, _] -> content_type
-      [content_type]    -> content_type
-    end
+    [content_type | _] = String.split(binary, ";")
+    content_type
   end
 
   defp parse_content_type(content_type) do

--- a/test/oauth2/util_test.exs
+++ b/test/oauth2/util_test.exs
@@ -7,6 +7,7 @@ defmodule OAuth2.UtilTest do
     assert "application/json" == Util.content_type([])
     assert "application/vnd.api+json" == Util.content_type([{"content-type", "application/vnd.api+json"}])
     assert "application/xml" == Util.content_type([{"content-type", "application/xml; version=1.0"}])
+    assert "application/json" == Util.content_type([{"content-type", "application/json;param;param"}])
 
     assert_raise OAuth2.Error, fn ->
       Util.content_type([{"content-type", "trash; trash"}])


### PR DESCRIPTION
Microsoft's Azure AD v2.0 token endpoint responds with a Content-Type
containing multiple parameters, but the previous code only processes
cases with a content type, with or without a single parameter.