### PR TITLE
Changes `%{}` into correct map type specifications

### DIFF
--- a/lib/oauth2/access_token.ex
+++ b/lib/oauth2/access_token.ex
@@ -18,8 +18,8 @@ defmodule OAuth2.AccessToken do
   @type refresh_token :: binary | nil
   @type expires_at    :: integer
   @type token_type    :: binary
-  @type other_params  :: %{}
-  @type body          :: binary | %{}
+  @type other_params  :: %{binary => binary}
+  @type body          :: binary | map
 
   @type t :: %__MODULE__{
               access_token:  access_token,


### PR DESCRIPTION
It looks like [`%{}` stands for only "empty" maps in typespecs](https://hexdocs.pm/elixir/typespecs.html#literals) (whereas it can match for "any" maps on pattern matches).

So, currently codes like below are warned by dialyzer:

```ex
  defp ensure_admin_domain(%OAuth2.AccessToken{other_params: %{"id_token" => id_token}}) do
    # Parse id_token of OpenID Connect, check authorizing user's domain
    # ...
  end
  defp ensure_admin_domain(otherwise) do
    {:error, :id_token_not_found}
  end
```

```
$ mix dialyze # Using https://github.com/fishcakez/dialyze
Finding applications for analysis
Finding suitable PLTs
Looking up modules in dialyze_erlang-20.0_elixir-1.5.3_deps-dev.plt
Finding applications for dialyze_erlang-20.0_elixir-1.5.3_deps-dev.plt
Finding modules for dialyze_erlang-20.0_elixir-1.5.3_deps-dev.plt
Checking 1725 modules in dialyze_erlang-20.0_elixir-1.5.3_deps-dev.plt
Finding modules for analysis
Analysing 33 modules with dialyze_erlang-20.0_elixir-1.5.3_deps-dev.plt
web/repo/admin_token.ex:50: The pattern #{'other_params':=#{#{#<105>(8, 1, 'integer', ['unsigned', 'big']), #<100>(8, 1, 'integer', ['unsigned', 'big']), #<95>(8, 1, 'integer', ['unsigned', 'big']), #<116>(8, 1, 'integer', ['unsigned', 'big']), #<111>(8, 1, 'integer', ['unsigned', 'big']), #<107>(8, 1, 'integer', ['unsigned', 'big']), #<101>(8, 1, 'integer', ['unsigned', 'big']), #<110>(8, 1, 'integer', ['unsigned', 'big'])}#:=_id_token@1}, '__struct__':='Elixir.OAuth2.AccessToken'} can never match the type #{'__struct__':='Elixir.OAuth2.AccessToken', 'access_token':=binary(), 'expires_at':=integer(), 'other_params':=#{}, 'refresh_token':='nil' | binary(), 'token_type':=binary()}

** (Mix) Dialyzer reported 1 warnings
```

This PR fixes `other_params`'s typespec so that related codes will be correctly success-typed.

Also fixing `body` type as well, though it looks like `body` type is currently unused so it may well be removed. I can do that in this branch too, if requested.

And thanks for developing/maintaining this library! Looking for your reviews ❤️ 