### PR TITLE
Added handling of a "Content-Encoding" response of gzip or x-gzip

### DIFF
--- a/lib/oauth2/response.ex
+++ b/lib/oauth2/response.ex
@@ -29,7 +29,9 @@ defmodule OAuth2.Response do
   @doc false
   def new(code, headers, body) do
     headers = process_headers(headers)
-    body = decode_response_body(body, content_type(headers))
+
+    body = decode_response_body(body, content_encoding(headers))
+    body = parse_response_body(body, content_type(headers))
     resp = %__MODULE__{status_code: code, headers: headers, body: body}
 
     if Application.get_env(:oauth2, :debug) do
@@ -43,16 +45,22 @@ defmodule OAuth2.Response do
     Enum.map(headers, fn {k, v} -> {String.downcase(k), v} end)
   end
 
-  defp decode_response_body("", _type), do: ""
-  defp decode_response_body(" ", _type), do: ""
+  defp decode_response_body(body, nil), do: body
+  defp decode_response_body(body, ""), do: body
+  defp decode_response_body(body, "gzip"), do: :zlib.gunzip(body)
+  defp decode_response_body(body, "x-gzip"), do: :zlib.gunzip(body)
+  defp decode_response_body(body, encoding), do: body
+
+  defp parse_response_body("", _type), do: ""
+  defp parse_response_body(" ", _type), do: ""
   # Facebook sends text/plain tokens!?
-  defp decode_response_body(body, "text/plain") do
+  defp parse_response_body(body, "text/plain") do
     case URI.decode_query(body) do
       %{"access_token" => _} = token -> token
       _ -> body
     end
   end
-  defp decode_response_body(body, "application/x-www-form-urlencoded"),
+  defp parse_response_body(body, "application/x-www-form-urlencoded"),
     do: URI.decode_query(body)
-  defp decode_response_body(body, type), do: Serializer.decode!(body, type)
+  defp parse_response_body(body, type), do: Serializer.decode!(body, type)
 end

--- a/lib/oauth2/response.ex
+++ b/lib/oauth2/response.ex
@@ -45,11 +45,9 @@ defmodule OAuth2.Response do
     Enum.map(headers, fn {k, v} -> {String.downcase(k), v} end)
   end
 
-  defp decode_response_body(body, nil), do: body
-  defp decode_response_body(body, ""), do: body
   defp decode_response_body(body, "gzip"), do: :zlib.gunzip(body)
   defp decode_response_body(body, "x-gzip"), do: :zlib.gunzip(body)
-  defp decode_response_body(body, encoding), do: body
+  defp decode_response_body(body, _encoding), do: body
 
   defp parse_response_body("", _type), do: ""
   defp parse_response_body(" ", _type), do: ""

--- a/lib/oauth2/util.ex
+++ b/lib/oauth2/util.ex
@@ -6,6 +6,14 @@ defmodule OAuth2.Util do
     (mega * 1_000_000) + sec
   end
 
+  def content_encoding(headers) do
+    case get_content_encoding(headers) do
+      {_, content_encoding} ->
+        content_encoding
+      nil -> ""
+    end
+  end
+
   def content_type(headers) do
     case get_content_type(headers) do
       {_, content_type} ->
@@ -29,6 +37,10 @@ defmodule OAuth2.Util do
       [bad_type] ->
         raise OAuth2.Error, reason: "bad content-type: #{bad_type}"
     end
+  end
+
+  defp get_content_encoding(headers) do
+    List.keyfind(headers, "content-encoding", 0)
   end
 
   defp get_content_type(headers) do

--- a/test/oauth2/access_token_test.exs
+++ b/test/oauth2/access_token_test.exs
@@ -54,4 +54,23 @@ defmodule OAuth2.AccessTokenTest do
     assert AccessToken.expires_at("3600") == unix_now() + 3600
   end
 
+  test "no content-encoding" do
+    response = Response.new(200, [{"content-type", "text/plain"}], "Testing")
+    assert response.body == "Testing"
+  end
+
+  test "gzip content-encoding" do
+    response = Response.new(200, [{"content-type", "text/plain"}, {"content-encoding", "gzip"}], :zlib.gzip("Testing"))
+    assert response.body == "Testing"
+  end
+
+  test "x-gzip content-encoding" do
+    response = Response.new(200, [{"content-type", "text/plain"}, {"content-encoding", "x-gzip"}], :zlib.gzip("Testing"))
+    assert response.body == "Testing"
+  end
+
+  test "unknown content-encoding" do
+    response = Response.new(200, [{"content-type", "text/plain"}, {"content-encoding", "x-unknown"}], "Testing")
+    assert response.body == "Testing"
+  end
 end


### PR DESCRIPTION
I'm writing up an ueberauth strategy for StackOverflow and all their responses are gzip'd. For now, hackney doesn't handle this situation (see below for other issues pointing to it). So I need oauth2 to gunzip the body so it can read the StackOverflow response correctly. I've added tests for this case as well.

Assuming hackney removes the header when it handles the encoding, then this code should still be fine.

https://github.com/edgurgel/httpoison/issues/81
https://github.com/benoitc/hackney/issues/155
https://github.com/benoitc/hackney/pull/456