### PR TITLE
specify hackney requirements

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule OAuth2.Mixfile do
   end
 
   defp deps do
-    [{:hackney, "~> 1.7"},
+    [{:hackney, ">= 1.7.0 and <= 1.9.0"},
 
      # Test dependencies
      {:poison, "~> 3.0", only: :test},


### PR DESCRIPTION
***Description:***

- relax hackney requirements

- I didn't increase to `1.10.1` and `1.11.0` deliberately as there are some issues with those versions of hackney in the hackney issues list. But I can include them if needed.