### PR TITLE
Rename client to token in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ OAuth2.Client.authorize_url!(client)
 # => "https://auth.example.com/oauth/authorize?client_id=client_id&redirect_uri=https%3A%2F%2Fexample.com%2Fauth%2Fcallback&response_type=code"
 
 # Use the authorization code returned from the provider to obtain an access token.
-client = OAuth2.Client.get_token!(client, code: "someauthcode")
+token = OAuth2.Client.get_token!(client, code: "someauthcode")
 
 # Use the access token to make a request for resources
-resource = OAuth2.Client.get!(client, "/api/resource").body
+resource = OAuth2.Client.get!(token, "/api/resource").body
 ```
 
 ## Write Your Own Strategy


### PR DESCRIPTION
While attempting to update an old application, I was confused by the re-use of the 'client' variable to refer to the token that is returned by the call to `OAuth2.Client.get_token!`.