### PR TITLE
Fix typespecs for OAuth2.Client.refresh_token

### DIFF
--- a/lib/oauth2/client.ex
+++ b/lib/oauth2/client.ex
@@ -265,7 +265,7 @@ defmodule OAuth2.Client do
   @doc """
   Refreshes an existing access token using a refresh token.
   """
-  @spec refresh_token(t, params, headers, Keyword.t) :: {:ok, Client.t} | {:error, Error.t}
+  @spec refresh_token(t, params, headers, Keyword.t) :: {:ok, Client.t} | {:error, Response.t} | {:error, Error.t}
   def refresh_token(token, params \\ [], headers \\ [], opts \\ [])
   def refresh_token(%Client{token: %{refresh_token: nil}}, _params, _headers, _opts) do
     {:error, %Error{reason: "Refresh token not available."}}


### PR DESCRIPTION
This should close https://github.com/scrogson/oauth2/issues/119

Looks like `get_token` was already correct, and it's just `refresh_token` that was missing the annotation :)