### PR TITLE
Relax hackney version requirement

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule OAuth2.Mixfile do
   end
 
   defp deps do
-    [{:hackney, ">= 1.7.0 and <= 1.9.0"},
+    [{:hackney, "~> 1.7"},
 
      # Test dependencies
      {:poison, "~> 3.0", only: :test},


### PR DESCRIPTION
This pull request relaxes the version requirements for Hackney same as #121, but that seems to have been abandoned with Travis failing. Unless there are any objections I have overlooked, I would love to see this merged and pushed to Hex.