### PR TITLE
Allowing 'expires_at' key when constructing AccessToken

### DIFF
--- a/lib/oauth2/access_token.ex
+++ b/lib/oauth2/access_token.ex
@@ -12,7 +12,7 @@ defmodule OAuth2.AccessToken do
 
   alias OAuth2.AccessToken
 
-  @standard ["access_token", "refresh_token", "expires_in", "token_type"]
+  @standard ["access_token", "refresh_token", "expires_in", "expires_at", "token_type"]
 
   @type access_token  :: binary
   @type refresh_token :: binary | nil
@@ -61,8 +61,8 @@ defmodule OAuth2.AccessToken do
     struct(AccessToken, [
       access_token:  std["access_token"],
       refresh_token: std["refresh_token"],
-      expires_at:    (std["expires_in"] || other["expires"]) |> expires_at,
-      token_type:    std["token_type"] |> normalize_token_type(),
+      expires_at:    parse_timestamp(std["expires_at"]) || expires_at(std["expires_in"] || other["expires"]),
+      token_type:    normalize_token_type(std["token_type"]),
       other_params:  other
     ])
   end
@@ -94,6 +94,14 @@ defmodule OAuth2.AccessToken do
     |> expires_at
   end
   def expires_at(int), do: unix_now() + int
+
+  defp parse_timestamp(nil), do: nil
+  defp parse_timestamp(timestamp) when is_integer(timestamp), do: timestamp
+  defp parse_timestamp(timestamp) when is_binary(timestamp) do
+    timestamp
+    |> Integer.parse
+    |> elem(0)
+  end
 
   defp normalize_token_type(nil), do: "Bearer"
   defp normalize_token_type("bearer"), do: "Bearer"

--- a/test/oauth2/access_token_test.exs
+++ b/test/oauth2/access_token_test.exs
@@ -29,6 +29,15 @@ defmodule OAuth2.AccessTokenTest do
     assert token.other_params == %{"expires" => "123"}
   end
 
+  test "new with 'expires_at' param" do
+    response = Response.new(200, [{"content-type", "application/x-www-form-urlencoded"}], "access_token=abc123&expires_at=123")
+    token = AccessToken.new(response.body)
+    assert token.access_token == "abc123"
+    assert token.expires_at == 123
+    assert token.token_type == "Bearer"
+    assert token.other_params == %{}
+  end
+
   test "new from text/plain content-type" do
     response = Response.new(200, [{"content-type", "text/plain"}], "access_token=abc123&expires=123")
     token = AccessToken.new(response.body)


### PR DESCRIPTION
Currently the `AccessToken.new/1` method does not use the `expires_at` param if it is present in the given map, and only uses `expires_in` or `expires`. It is common to store access tokens in the DB, so when fetching them back and re-constructing the `AccessToken` struct it should Just Work™️.

This PR changes that to use `expires_at` when it is already present