### PR TITLE
Require Poison outside tests

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -28,9 +28,9 @@ defmodule OAuth2.Mixfile do
 
   defp deps do
     [{:hackney, "~> 1.7"},
+     {:poison, "~> 3.0"},
 
      # Test dependencies
-     {:poison, "~> 3.0", only: :test},
      {:bypass, "~> 0.6", only: :test},
      {:excoveralls, "~> 0.5", only: :test},
      {:dialyxir, "~> 0.5", only: [:dev], runtime: false},


### PR DESCRIPTION
If no serializers are set, `OAuth2.Serializer` defaults to using Poison.

```elixir
# mix.exs
def application do
  [applications: [:logger, :hackney],
   env: [serializers: %{"application/json" => Poison}]]
end
```
This makes Poison a required runtime dependency.

I bumped into this issue after replacing Poison with Jason and running `mix deps.clean --unused`. Without the explicit requirement, Poison is removed even when code relies on it.