### PR TITLE
Always parse body by serializer if it exists

### DIFF
--- a/lib/oauth2/response.ex
+++ b/lib/oauth2/response.ex
@@ -47,6 +47,9 @@ defmodule OAuth2.Response do
 
   defp decode_response_body("", _type, _), do: ""
   defp decode_response_body(" ", _type, _), do: ""
+  defp decode_response_body(body, _type, serializer) when serializer != nil do
+    serializer.decode!(body)
+  end
   # Facebook sends text/plain tokens!?
   defp decode_response_body(body, "text/plain", _) do
     case URI.decode_query(body) do
@@ -59,8 +62,5 @@ defmodule OAuth2.Response do
   end
   defp decode_response_body(body, _mime, nil) do
     body
-  end
-  defp decode_response_body(body, _type, serializer) do
-    serializer.decode!(body)
   end
 end

--- a/test/oauth2/response_test.exs
+++ b/test/oauth2/response_test.exs
@@ -19,4 +19,10 @@ defmodule OAuth2.ResponseTest do
     response = Response.new(%OAuth2.Client{}, 200, [{"content-type", "text/plain"}], "hello")
     assert response.body == "hello"
   end
+
+  test "always parse body by serializer if it exists" do
+    client = OAuth2.Client.put_serializer(%OAuth2.Client{}, "text/plain", Jason)
+    response = Response.new(client, 200, [{"content-type", "text/plain"}], ~S({"hello": "world"}))
+    assert response.body == %{"hello" => "world"}
+  end
 end


### PR DESCRIPTION
If there is a serializer for a specified content type, it should always be used to parse the response body.

Fix #133 