### PR TITLE
fix body type

### DIFF
--- a/lib/oauth2/response.ex
+++ b/lib/oauth2/response.ex
@@ -16,7 +16,7 @@ defmodule OAuth2.Response do
 
   @type status_code :: integer
   @type headers     :: list
-  @type body        :: binary | map
+  @type body        :: binary | map | list
 
   @type t :: %__MODULE__{
     status_code: status_code,


### PR DESCRIPTION
The response body can also be a list, which is currently not reflected in the type.