### PR TITLE
Restrict sensitive values from Inspect

### DIFF
--- a/lib/oauth2/access_token.ex
+++ b/lib/oauth2/access_token.ex
@@ -29,6 +29,7 @@ defmodule OAuth2.AccessToken do
           other_params: other_params
         }
 
+  @derive {Inspect, except: [:access_token, :refresh_token]}
   defstruct access_token: "",
             refresh_token: nil,
             expires_at: nil,

--- a/lib/oauth2/client.ex
+++ b/lib/oauth2/client.ex
@@ -65,6 +65,7 @@ defmodule OAuth2.Client do
           token_url: token_url
         }
 
+  @derive {Inspect, except: [:client_secret, :token]}
   defstruct authorize_url: "/oauth/authorize",
             client_id: "",
             client_secret: "",

--- a/test/oauth2/access_token_test.exs
+++ b/test/oauth2/access_token_test.exs
@@ -2,6 +2,7 @@ defmodule OAuth2.AccessTokenTest do
   use ExUnit.Case, async: true
   doctest OAuth2.AccessToken
 
+  import ExUnit.CaptureIO
   import OAuth2.TestHelpers, only: [unix_now: 0]
 
   alias OAuth2.{AccessToken, Client, Response}
@@ -73,5 +74,13 @@ defmodule OAuth2.AccessTokenTest do
     assert AccessToken.expires_at(nil) == nil
     assert AccessToken.expires_at(3600) == unix_now() + 3600
     assert AccessToken.expires_at("3600") == unix_now() + 3600
+  end
+
+  test "does not log sensitive values" do
+    token = %AccessToken{access_token: "abc123", refresh_token: "def456"}
+    captured_string = capture_io(fn -> IO.inspect(token) end)
+    refute captured_string =~ "abc123"
+    refute captured_string =~ "def456"
+    assert captured_string =~ "Bearer"
   end
 end

--- a/test/oauth2/client_test.exs
+++ b/test/oauth2/client_test.exs
@@ -3,6 +3,7 @@ defmodule OAuth2.ClientTest do
   use Plug.Test
   doctest OAuth2.Client
 
+  import ExUnit.CaptureIO
   import OAuth2.Client
   import OAuth2.TestHelpers
 
@@ -369,5 +370,13 @@ defmodule OAuth2.ClientTest do
     end
 
     Bypass.up(server)
+  end
+
+  test "does not log sensitive values", %{client: client} do
+    client = %Client{client_id: client.client_id, client_secret: "abc123", token: "def456"}
+    captured_string = capture_io(fn -> IO.inspect(client) end)
+    refute captured_string =~ "abc123"
+    refute captured_string =~ "def456"
+    assert captured_string =~ client.client_id
   end
 end


### PR DESCRIPTION
With no restrictions put on the inspect values of `access_token` and `client`, it's currently possible to leak sensitive values into log files or other logger backends.  This PR removes the sensitive values that I am aware of.

I think I have everything covered by tests, but let me know if I missed something and I'll get it fixed for you.