### PR TITLE
[don't merge] AccessToken not getting decoded

### DIFF
--- a/lib/oauth2/client.ex
+++ b/lib/oauth2/client.ex
@@ -281,7 +281,7 @@ defmodule OAuth2.Client do
           {:ok, %{client | headers: [], params: %{}, token: token}}
         else
           token = AccessToken.new(response.body)
-          {:ok, %{client | headers: [], params: %{}, token: body}}
+          {:ok, %{client | headers: [], params: %{}, token: token}}
         end
       {:error, error} ->
         {:error, error}

--- a/lib/oauth2/client.ex
+++ b/lib/oauth2/client.ex
@@ -276,12 +276,12 @@ defmodule OAuth2.Client do
 
     case Request.request(method, client, url, client.params, client.headers, opts) do
       {:ok, response} ->
-        token = AccessToken.new(response.body)
-        if token =~ ~r/\{/ do
-          %{"access_token" => token} = Jason.decode!(token)
+        if response.body =~ ~r/\{/ do
+          %{"access_token" => token} = Jason.decode!(response.body)
           {:ok, %{client | headers: [], params: %{}, token: token}}
         else
-          {:ok, %{client | headers: [], params: %{}, token: token}}
+          token = AccessToken.new(response.body)
+          {:ok, %{client | headers: [], params: %{}, token: body}}
         end
       {:error, error} ->
         {:error, error}

--- a/lib/oauth2/client.ex
+++ b/lib/oauth2/client.ex
@@ -278,7 +278,6 @@ defmodule OAuth2.Client do
       {:ok, response} ->
         token = AccessToken.new(Jason.decode!(response.body))
         {:ok, %{client | headers: [], params: %{}, token: token}}
-        end
       {:error, error} ->
         {:error, error}
     end

--- a/lib/oauth2/client.ex
+++ b/lib/oauth2/client.ex
@@ -276,12 +276,8 @@ defmodule OAuth2.Client do
 
     case Request.request(method, client, url, client.params, client.headers, opts) do
       {:ok, response} ->
-        if response.body =~ ~r/\{/ do
-          %{"access_token" => token} = Jason.decode!(response.body)
-          {:ok, %{client | headers: [], params: %{}, token: token}}
-        else
-          token = AccessToken.new(response.body)
-          {:ok, %{client | headers: [], params: %{}, token: token}}
+        token = AccessToken.new(Jason.decode!(response.body))
+        {:ok, %{client | headers: [], params: %{}, token: token}}
         end
       {:error, error} ->
         {:error, error}

--- a/lib/oauth2/client.ex
+++ b/lib/oauth2/client.ex
@@ -277,8 +277,12 @@ defmodule OAuth2.Client do
     case Request.request(method, client, url, client.params, client.headers, opts) do
       {:ok, response} ->
         token = AccessToken.new(response.body)
-        {:ok, %{client | headers: [], params: %{}, token: token}}
-
+        if token =~ ~r/\{/ do
+          %{"access_token" => token} = Jason.decode!(token)
+          {:ok, %{client | headers: [], params: %{}, token: token}}
+        else
+          {:ok, %{client | headers: [], params: %{}, token: token}}
+        end
       {:error, error} ->
         {:error, error}
     end

--- a/mix.exs
+++ b/mix.exs
@@ -31,9 +31,9 @@ defmodule OAuth2.Mixfile do
   defp deps do
     [
       {:hackney, "~> 1.13"},
+      {:jason, "~> 1.0"},
 
       # Test dependencies
-      {:jason, "~> 1.0", only: [:dev, :test]},
       {:bypass, "~> 0.9", only: :test},
       {:plug_cowboy, "~> 1.0", only: :test},
       {:excoveralls, "~> 0.9", only: :test},


### PR DESCRIPTION
I was hacking around for a demo and for some reason the access token wasn't getting decoded. Other JSON repsonses weren't getting decoded either - could have sworn this package did that.

I'm currently not using this for anything and don't remember any other context, but figured reporting the issue might be useful to someone.