### PR TITLE
Add support for JSON responses from the server

### DIFF
--- a/lib/oauth2/client.ex
+++ b/lib/oauth2/client.ex
@@ -363,7 +363,7 @@ defmodule OAuth2.Client do
   """
   @spec basic_auth(t) :: t
   def basic_auth(%OAuth2.Client{client_id: id, client_secret: secret} = client) do
-    put_header(client, "authorization", "Basic " <> Base.encode64(id <> ":" <> secret))
+    put_header(client, "authorization", "Basic " <> client_auth(id, secret))
   end
 
   @doc """
@@ -460,6 +460,15 @@ defmodule OAuth2.Client do
   @spec delete!(t, binary, body, headers, Keyword.t()) :: Response.t() | Error.t()
   def delete!(%Client{} = client, url, body \\ "", headers \\ [], opts \\ []),
     do: Request.request!(:delete, client, url, body, headers, opts)
+
+  defp client_auth(id, secret) do
+    # Format the client identifier for basic auth according to RFC 6749 section 2.3.1 and Appendix B:
+    # https://tools.ietf.org/html/rfc6749#section-2.3.1
+    [id, secret]
+    |> Enum.map(&(URI.encode(&1)))
+    |> Enum.join(":")
+    |> Base.encode64
+  end
 
   defp to_url(%Client{token_method: :post} = client, :token_url) do
     {client, endpoint(client, client.token_url)}

--- a/lib/oauth2/response.ex
+++ b/lib/oauth2/response.ex
@@ -10,6 +10,7 @@ defmodule OAuth2.Response do
   * `body` - Parsed HTTP response body (based on "content-type" header)
   """
 
+  require Jason
   require Logger
   import OAuth2.Util
   alias OAuth2.Client
@@ -63,6 +64,11 @@ defmodule OAuth2.Response do
 
   defp decode_response_body(body, "application/x-www-form-urlencoded", _) do
     URI.decode_query(body)
+  end
+
+  # Okta responds with JSON
+  defp decode_response_body(body, "application/json", _) do
+    Jason.decode!(body)
   end
 
   defp decode_response_body(body, _mime, nil) do

--- a/mix.exs
+++ b/mix.exs
@@ -30,10 +30,10 @@ defmodule OAuth2.Mixfile do
 
   defp deps do
     [
+      {:jason, "~> 1.0"},
       {:hackney, "~> 1.13"},
 
       # Test dependencies
-      {:jason, "~> 1.0", only: [:dev, :test]},
       {:bypass, "~> 0.9", only: :test},
       {:plug_cowboy, "~> 1.0", only: :test},
       {:excoveralls, "~> 0.9", only: :test},


### PR DESCRIPTION
This defines a new pattern for `decode_response_body` to support JSON.

Okta for example sends the response with the access token as a JSON.
