### PR TITLE
Incorrect content-type used to format body on request

### DIFF
--- a/lib/oauth2/request.ex
+++ b/lib/oauth2/request.ex
@@ -15,7 +15,7 @@ defmodule OAuth2.Request do
           {:ok, Response.t()} | {:ok, reference} | {:error, Response.t()} | {:error, Error.t()}
   def request(method, %Client{} = client, url, body, headers, opts) do
     url = client |> process_url(url) |> process_params(opts[:params])
-    headers = req_headers(client, headers) |> Enum.uniq()
+    headers = req_headers(client, headers) |> normalize_headers() |> Enum.uniq()
     content_type = content_type(headers)
     serializer = Client.get_serializer(client, content_type)
     body = encode_request_body(body, content_type, serializer)
@@ -121,6 +121,9 @@ defmodule OAuth2.Request do
 
   defp req_headers(%Client{token: token} = client, headers),
     do: [authorization_header(token) | headers] ++ client.headers
+
+  defp normalize_headers(headers),
+    do: Enum.map(headers, fn {key, val} -> {to_string(key), val} end)
 
   defp authorization_header(token),
     do: {"authorization", "#{token.token_type} #{token.access_token}"}

--- a/lib/oauth2/util.ex
+++ b/lib/oauth2/util.ex
@@ -36,6 +36,6 @@ defmodule OAuth2.Util do
   end
 
   defp get_content_type(headers) do
-    List.keyfind(headers, "content-type", 0)
+    Enum.find(headers, fn {key, _val} -> String.downcase(key) == "content-type" end)
   end
 end

--- a/test/oauth2/util_test.exs
+++ b/test/oauth2/util_test.exs
@@ -15,6 +15,8 @@ defmodule OAuth2.UtilTest do
     assert "application/json" ==
              Util.content_type([{"content-type", "application/json;param;param"}])
 
+    assert "vendor/specific" == Util.content_type([{"Content-Type", "vendor/specific"}])
+
     assert_raise OAuth2.Error, fn ->
       Util.content_type([{"content-type", "trash; trash"}])
     end


### PR DESCRIPTION
Happens if the Content-Type header is not all lower case.

The current workaround is to either use only lowercase header names, or to unset the serializers before making a request.