### PR TITLE
Making request with mixed case headers can mess up request

### DIFF
--- a/lib/oauth2/request.ex
+++ b/lib/oauth2/request.ex
@@ -15,7 +15,7 @@ defmodule OAuth2.Request do
           {:ok, Response.t()} | {:ok, reference} | {:error, Response.t()} | {:error, Error.t()}
   def request(method, %Client{} = client, url, body, headers, opts) do
     url = client |> process_url(url) |> process_params(opts[:params])
-    headers = req_headers(client, headers) |> Enum.uniq()
+    headers = req_headers(client, headers) |> normalize_headers() |> Enum.uniq()
     content_type = content_type(headers)
     serializer = Client.get_serializer(client, content_type)
     body = encode_request_body(body, content_type, serializer)
@@ -124,6 +124,9 @@ defmodule OAuth2.Request do
 
   defp authorization_header(token),
     do: {"authorization", "#{token.token_type} #{token.access_token}"}
+
+  defp normalize_headers(headers),
+    do: Enum.map(headers, fn {key, val} -> {to_string(key) |> String.downcase(), val} end)
 
   defp process_request_headers(headers, content_type) do
     case List.keyfind(headers, "accept", 0) do


### PR DESCRIPTION
I.e. when making a request with "Content-Type": "application/multipart",
the content type will not be matched correctly and the serializer for
"application/json" will be incorrectly applied to the body.

The same problem happens for the "accept" header, if the content type
is parsed correctly, but "Accept" in the params uses an uppercase "A".

The workaround for those issues for now is to simply use only lowercase
headers, and no atoms.